### PR TITLE
Fix typo on authSSODisabledError

### DIFF
--- a/admin/src/main/scala/com/neu/api/BaseService.scala
+++ b/admin/src/main/scala/com/neu/api/BaseService.scala
@@ -11,7 +11,7 @@ import java.io.{PrintWriter, StringWriter}
 
 class BaseService() extends Directives with LazyLogging {
   val authError                  = "Authentication failed!"
-  val authSSODisabledError       = "Authenticate using OpenShift's or Rancher's RBAC was disabled!"
+  val authSSODisabledError       = "Authentication using OpenShift's or Rancher's RBAC was disabled!"
   val blocked                    = "Temporarily blocked because of too many login failures"
   val passwordExpired            = "Password expired"
   val timeOutStatus              = "Status: 408"


### PR DESCRIPTION
Fixes a typo on authSSODisabledError when Rancher/OpenShift auth is disabled.

Resolves https://github.com/neuvector/neuvector/issues/299 