### PR TITLE
UI Issue: PCAP downloads are named "pocket_nnnnnnn"

### DIFF
--- a/admin/webapp/root/app_src/js/nv/event/securityEventsController.js
+++ b/admin/webapp/root/app_src/js/nv/event/securityEventsController.js
@@ -2365,7 +2365,7 @@
           let blob = new Blob([blockHeader, sectionLen, sectionLen, pcap], {
             type: "application/octet-stream"
           });
-          FileSaver.saveAs(blob, `pocket_${Utils.parseDatetimeStr(new Date())}.pcap`);
+          FileSaver.saveAs(blob, `packet_${Utils.parseDatetimeStr(new Date())}.pcap`);
         }
       };
 

--- a/admin/webapp/root/app_src/js/nv/event/threatController.js
+++ b/admin/webapp/root/app_src/js/nv/event/threatController.js
@@ -493,7 +493,7 @@
           }
 
           let blob = new Blob([blockHeader, sectionLen, sectionLen, pcap], { type: "application/octet-stream" });
-          FileSaver.saveAs(blob, "pocket.pcap");
+          FileSaver.saveAs(blob, "packet.pcap");
         }
       };
     }


### PR DESCRIPTION
Fix Jira case 6265: UI Issue: PCAP downloads are named "pocket_nnnnnnn"