### PR TITLE
NV5.1 Cases

### DIFF
--- a/admin/webapp/websrc/app/common/api/auth-http.service.ts
+++ b/admin/webapp/websrc/app/common/api/auth-http.service.ts
@@ -97,6 +97,10 @@ export class AuthHttpService {
     return GlobalVariable.http.patch<unknown>(PathConstant.LDAP_URL, body);
   }
 
+  postServer(body: ServerPatchBody): Observable<unknown> {
+    return GlobalVariable.http.post<unknown>(PathConstant.LDAP_URL, body);
+  }
+
   getPermissionOptions(): Observable<PermissionOptionResponse> {
     return GlobalVariable.http
       .get<PermissionOptionResponse>(PathConstant.PERMISSION_OPTIONS)

--- a/admin/webapp/websrc/app/common/services/settings.service.ts
+++ b/admin/webapp/websrc/app/common/services/settings.service.ts
@@ -75,6 +75,10 @@ export class SettingsService {
     return this.authHttpService.patchServer(body);
   }
 
+  postServer(body: ServerPatchBody) {
+    return this.authHttpService.postServer(body);
+  }
+
   getDomain() {
     return this.assetsHttpService.getDomain();
   }

--- a/admin/webapp/websrc/app/common/types/settings/settings.ts
+++ b/admin/webapp/websrc/app/common/types/settings/settings.ts
@@ -124,7 +124,7 @@ export interface ServerPatchBody {
     name: string;
     ldap?: LDAP;
     saml?: SAML;
-    openid?: OPENID;
+    oidc?: OPENID;
   };
 }
 

--- a/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.ts
@@ -254,22 +254,16 @@ export class ContainersGridComponent implements OnInit {
   }
 
   postSort(nodes: RowNode[]): void {
+    // sort parents first
     nodes = nodes.sort((a, b) =>
       !a.data.parent_id ? -1 : !b.data.parent_id ? 1 : 0
     );
-    let lastParentIdx = -1;
     for (let i = 0; i < nodes.length; i++) {
       const pid = nodes[i].data.parent_id;
       if (pid) {
         const pidx = nodes.findIndex(node => node.data.brief.id === pid);
-        if (lastParentIdx !== pidx) {
-          nodes.splice(pidx + 1, 0, nodes.splice(i, 1)[0]);
-          if (pidx > i) {
-            i--;
-          }
-        }
-      } else {
-        lastParentIdx = i;
+        // splice child after parent
+        nodes.splice(pidx + 1, 0, nodes.splice(i, 1)[0]);
       }
     }
   }

--- a/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
+++ b/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
@@ -71,6 +71,9 @@ export class RegistriesCommunicationService {
           })
         );
       }
+      if (!summarys.length) {
+        this.refreshingDetailsSubject$.next(false);
+      }
     }),
     finalize(() => {
       if (this.refreshingDetailsSubject$.value) {

--- a/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
+++ b/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
@@ -109,6 +109,10 @@ export class RegistriesCommunicationService {
     this.savingSubject$.next(true);
   }
 
+  cancelSave(): void {
+    this.savingSubject$.next(false);
+  }
+
   initDelete(): void {
     this.deletingSubject$.next(true);
   }

--- a/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/add-registry-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/add-registry-dialog.component.html
@@ -24,6 +24,7 @@
       {{ 'general.CANCEL' | translate }}
     </button>
     <app-loading-button
+      *ngIf="data.editable"
       [disabled]="form.invalid || submittingForm || !!(saving$ | async)"
       [loading]="submittingForm || !!(saving$ | async)"
       [text]="'general.SUBMIT' | translate"

--- a/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/add-registry-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/add-registry-dialog.component.ts
@@ -17,6 +17,7 @@ import { cloneDeep } from 'lodash';
 import { INTERVAL_STEP_VALUES } from './add-registry-form-configs/constants/constants';
 import {
   AWSKey,
+  ErrorResponse,
   GCRKey,
   RegistryConfig,
   RegistryPostBody,
@@ -27,6 +28,7 @@ import { finalize, switchMap, take } from 'rxjs/operators';
 import { TestSettingsDialogComponent } from './test-connection-dialog/test-settings-dialog.component';
 import { RegistriesCommunicationService } from '../../regestries-communication.service';
 import { GlobalConstant } from '@common/constants/global.constant';
+import { NotificationService } from '@services/notification.service';
 
 @Component({
   selector: 'app-add-registry-dialog',
@@ -49,7 +51,8 @@ export class AddRegistryDialogComponent implements OnInit, AfterViewChecked {
     public dialogRef: MatDialogRef<RegistriesTableComponent>,
     @Inject(MAT_DIALOG_DATA) public data: RegistryConfig,
     private registriesService: RegistriesService,
-    private registriesCommunicationService: RegistriesCommunicationService
+    private registriesCommunicationService: RegistriesCommunicationService,
+    private notificationService: NotificationService
   ) {}
 
   submit(): void {
@@ -103,7 +106,9 @@ export class AddRegistryDialogComponent implements OnInit, AfterViewChecked {
       if (!body.config.auth_with_token) {
         body.config.auth_with_token = false;
       }
-      body.config.cfg_type = this.model.isFed ? GlobalConstant.CFG_TYPE.FED : GlobalConstant.CFG_TYPE.CUSTOMER;
+      body.config.cfg_type = this.model.isFed
+        ? GlobalConstant.CFG_TYPE.FED
+        : GlobalConstant.CFG_TYPE.CUSTOMER;
       this.submittingForm = true;
       if (this.model?.isEdit) {
         body.config.password =
@@ -118,14 +123,21 @@ export class AddRegistryDialogComponent implements OnInit, AfterViewChecked {
             take(1),
             finalize(() => {
               this.submittingForm = false;
-              this.registriesCommunicationService.refreshRegistries();
-            }),
-            switchMap(() => this.saving$)
+            })
           )
-          .subscribe(saving => {
-            if (!saving) {
-              this.dialogRef.close();
-            }
+          .subscribe({
+            complete: () => {
+              this.registriesCommunicationService.refreshRegistries();
+              this.saving$.subscribe(saving => {
+                if (!saving) {
+                  this.dialogRef.close();
+                }
+              });
+            },
+            error: ({ error }: { error: ErrorResponse }) => {
+              this.registriesCommunicationService.cancelSave();
+              this.notificationService.open(error.message);
+            },
           });
       } else {
         this.registriesService
@@ -133,14 +145,21 @@ export class AddRegistryDialogComponent implements OnInit, AfterViewChecked {
           .pipe(
             finalize(() => {
               this.submittingForm = false;
-              this.registriesCommunicationService.refreshRegistries();
-            }),
-            switchMap(() => this.saving$)
+            })
           )
-          .subscribe(saving => {
-            if (!saving) {
-              this.dialogRef.close();
-            }
+          .subscribe({
+            complete: () => {
+              this.registriesCommunicationService.refreshRegistries();
+              this.saving$.subscribe(saving => {
+                if (!saving) {
+                  this.dialogRef.close();
+                }
+              });
+            },
+            error: ({ error }: { error: ErrorResponse }) => {
+              this.registriesCommunicationService.cancelSave();
+              this.notificationService.open(error.message);
+            },
           });
       }
     }

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
@@ -20,3 +20,11 @@
     <i class="eos-icons">delete</i>
   </button>
 </div>
+<button
+  *ngIf="!isWriteRegistryAuthorized"
+  (click)="view()"
+  aria-label="View button"
+  matTooltip="{{ 'registry.TIP.VIEW' | translate }}"
+  mat-icon-button>
+  <mat-icon fontSet="fa" fontIcon="fa-newspaper"></mat-icon>
+</button>

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
@@ -1,8 +1,22 @@
-<div *ngIf="(params.data.cfg_type === CFG_TYPE.FED && isWriteRegistryAuthorized && isFedAdmin) || (params.data.cfg_type === CFG_TYPE.CUSTOMER && isWriteRegistryAuthorized)">
-  <button (click)="edit()" aria-label="Edit button" mat-icon-button>
+<div
+  *ngIf="
+    (params.data.cfg_type === CFG_TYPE.FED &&
+      isWriteRegistryAuthorized &&
+      isFedAdmin) ||
+    (params.data.cfg_type === CFG_TYPE.CUSTOMER && isWriteRegistryAuthorized)
+  ">
+  <button
+    (click)="edit()"
+    aria-label="Edit button"
+    matTooltip="{{ 'registry.TIP.EDIT' | translate }}"
+    mat-icon-button>
     <i class="eos-icons">edit</i>
   </button>
-  <button (click)="delete()" aria-label="Delete button" mat-icon-button>
+  <button
+    (click)="delete()"
+    aria-label="Delete button"
+    matTooltip="{{ 'registry.TIP.DELETE' | translate }}"
+    mat-icon-button>
     <i class="eos-icons">delete</i>
   </button>
 </div>

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.ts
@@ -15,14 +15,10 @@ export class RegistriesTableButtonsComponent
 {
   params: any;
   CFG_TYPE = GlobalConstant.CFG_TYPE;
-  isWriteRegistryAuthorized: boolean;
-  isFedAdmin: boolean;
+  isWriteRegistryAuthorized!: boolean;
+  isFedAdmin!: boolean;
 
-  constructor(
-    private authUtilsService: AuthUtilsService
-  ) {
-
-  }
+  constructor(private authUtilsService: AuthUtilsService) {}
 
   agInit(params: any): void {
     this.params = params;
@@ -37,6 +33,10 @@ export class RegistriesTableButtonsComponent
 
   delete(): void {
     this.params.delete(this.params);
+  }
+
+  view(): void {
+    this.params.view(this.params);
   }
 
   refresh(params: ICellRendererParams): boolean {

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
@@ -131,6 +131,7 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
       cellRendererParams: {
         edit: event => this.editRegistry(event),
         delete: event => this.deleteRegistry(event),
+        view: event => this.viewRegistry(event),
       },
       cellClass: ['d-flex', 'align-items-center'],
     },
@@ -150,11 +151,6 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
-    let isWriteRegistryAuthorized =
-      this.authUtilsService.getDisplayFlag('registry_scan');
-    if (!isWriteRegistryAuthorized) {
-      this.columnDefs.pop();
-    }
     this.gridOptions = {
       rowData: this.rowData,
       columnDefs: this.columnDefs,
@@ -261,6 +257,13 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
     this.openDialog(cloneDeep(this.gridApi.getRowNode(event.node.id)?.data));
   }
 
+  viewRegistry(event): void {
+    this.openDialog(
+      cloneDeep(this.gridApi.getRowNode(event.node.id)?.data),
+      false
+    );
+  }
+
   onGridReady(params: GridReadyEvent): void {
     this.gridApi = params.api;
     this.gridApi.sizeColumnsToFit();
@@ -274,11 +277,11 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
     this.gridApi.sizeColumnsToFit();
   }
 
-  openDialog(data?: RegistryConfig): void {
+  openDialog(data?: RegistryConfig, editable = true): void {
     const dialog = this.dialog.open(AddRegistryDialogComponent, {
       width: '80%',
       maxWidth: '1100px',
-      data,
+      data: { config: data, editable },
     });
     dialog.afterClosed().subscribe(change => {
       this.cd.markForCheck();

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-overview/registry-overview.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-overview/registry-overview.component.ts
@@ -59,6 +59,7 @@ export class RegistryOverviewComponent implements OnChanges {
       const topFive = sortedRegistryDetails.slice(0, 5).map(image => {
         return {
           repository: image.repository,
+          tag: image.tag,
           vulnerabilities: { high: image.high, medium: image.medium },
         };
       });
@@ -69,6 +70,7 @@ export class RegistryOverviewComponent implements OnChanges {
         ...topFive.map(i => {
           return {
             repository: i.repository,
+            tag: i.tag,
             vulnerabilities: i.vulnerabilities.high + i.vulnerabilities.medium,
           };
         }),
@@ -96,7 +98,9 @@ export class RegistryOverviewComponent implements OnChanges {
         },
         data: {
           labels: topSix.map(item => {
-            return [item.repository];
+            return [
+              item.tag ? `${item.repository}:${item.tag}` : item.repository,
+            ];
           }),
           datasets: [
             {
@@ -139,7 +143,9 @@ export class RegistryOverviewComponent implements OnChanges {
         },
         data: {
           labels: topFive.map(item => {
-            return [item.repository];
+            return [
+              item.tag ? `${item.repository}:${item.tag}` : item.repository,
+            ];
           }),
           datasets: [
             {

--- a/admin/webapp/websrc/app/routes/settings/ldap/test-connection-dialog/test-connection-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/ldap/test-connection-dialog/test-connection-dialog.component.ts
@@ -5,6 +5,9 @@ import { DebugPostBody, ErrorResponse, LDAP } from '@common/types';
 import { finalize } from 'rxjs/operators';
 import { SettingsService } from '@services/settings.service';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { NotificationService } from '@services/notification.service';
+import { UtilsService } from '@common/utils/app.utils';
+import { TranslateService } from '@ngx-translate/core';
 
 export interface TestConnectionDialogData {
   ldap: LDAP;
@@ -29,7 +32,10 @@ export class TestConnectionDialogComponent {
   constructor(
     public dialogRef: MatDialogRef<LdapFormComponent>,
     @Inject(MAT_DIALOG_DATA) public data: TestConnectionDialogData,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private notificationService: NotificationService,
+    private utils: UtilsService,
+    private tr: TranslateService
   ) {}
 
   submitForm(): void {
@@ -53,12 +59,17 @@ export class TestConnectionDialogComponent {
         })
       )
       .subscribe({
+        complete: () => {
+          this.notificationService.open(this.tr.instant('ldap.test.SUCCEEDED'));
+        },
         error: ({ error }: { error: ErrorResponse }) => {
-          if (error.error && error.message) {
-            this.errorMessage = `${error.error}: ${error.message}`;
-          } else {
-            this.errorMessage = 'An error occurred. Please try again.';
-          }
+          this.notificationService.open(
+            this.utils.getAlertifyMsg(
+              error,
+              this.tr.instant('ldap.test.FAILED'),
+              false
+            )
+          );
         },
       });
   }

--- a/admin/webapp/websrc/app/routes/settings/openid/openid-form/openid-form.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/openid/openid-form/openid-form.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import {
   ErrorResponse,
   GroupMappedRole,
-  SAML,
+  OPENID,
   ServerGetResponse,
   ServerPatchBody,
 } from '@common/types';
@@ -24,7 +24,7 @@ export class OpenidFormComponent implements OnInit {
   submittingForm = false;
   errorMessage = '';
   groupMappedRoles: GroupMappedRole[] = [];
-  serverName = 'openid1';
+  serverName = 'openId1';
   passwordVisible = false;
   openidRedirectURL!: string;
 
@@ -68,12 +68,12 @@ export class OpenidFormComponent implements OnInit {
     if (!this.openidForm.valid) {
       return;
     }
-    const saml: SAML = {
+    const oidc: OPENID = {
       scopes: this.scopes,
       group_mapped_roles: this.groupMappedRoles,
       ...this.openidForm.value,
     };
-    const config: ServerPatchBody = { config: { name: this.serverName, saml } };
+    const config: ServerPatchBody = { config: { name: this.serverName, oidc } };
     this.submittingForm = true;
     this.errorMessage = '';
     this.settingsService


### PR DESCRIPTION
Addresses NV-5.1 cases:
- NVSHAS-6837: odic is unable saved successfully
- NVSHAS-6923: Error status code for creating registry is not handled well by UI
- NVSHAS-6849: child container is unable to show under parent one in containers page
- NVSHAS-6894: Settings -> LDAP/SAML/OIDC pages do not work as expected
- NVSHAS-6960: Refresh icon is always running after click refresh icon in Assets->Registries UI
- NVSHAS-6867: the tag info is missing in assets > registries > overview page
- NVSHAS-6897: unable to show tooltip when moving mouse over on icon in many pages
- NVSHAS-6879: the view icon is missing in assets > registries page if reader user is logged in