### PR TITLE
5.1.1 Cases

### DIFF
--- a/admin/webapp/websrc/app/common/api/assets-http.service.ts
+++ b/admin/webapp/websrc/app/common/api/assets-http.service.ts
@@ -183,6 +183,10 @@ export class AssetsHttpService {
     );
   }
 
+  postDomain(payload) {
+    return GlobalVariable.http.post<unknown>(PathConstant.DOMAIN_URL, payload);
+  }
+
   getControllers(): Observable<Controller[]> {
     return GlobalVariable.http
       .get<Controller[]>(PathConstant.CONTROLLER_URL)

--- a/admin/webapp/websrc/app/common/services/version-info.service.ts
+++ b/admin/webapp/websrc/app/common/services/version-info.service.ts
@@ -4,8 +4,8 @@ export type VersionInfoType = 'compliance' | 'vulnerabilities' | '';
 
 @Injectable()
 export class VersionInfoService {
-  private _infoData: any;
-  template!: VersionInfoType;
+  private _infoData: any = null;
+  template: VersionInfoType = '';
   get infoData() {
     return this._infoData;
   }

--- a/admin/webapp/websrc/app/common/utils/app.utils.ts
+++ b/admin/webapp/websrc/app/common/utils/app.utils.ts
@@ -425,6 +425,7 @@ export class UtilsService {
 
   exportCVE(name: string, vuls: Vulnerability[]) {
     vuls = vuls.map(vulnerability => {
+      vulnerability.in_base_image = vulnerability.in_base_image || false;
       vulnerability.description = `${vulnerability.description.replace(
         /\"/g,
         "'"

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.html
@@ -1,10 +1,27 @@
 <div class="d-flex flex-column justify-content-between pt-2">
   <p class="mx-3">{{ 'cis.profile.DESCRIPTION' | translate }}</p>
   <div class="row mx-3">
-    <div class="col-1 d-flex flex-column justify-content-around">
-      <span class="d-block">{{ 'cis.report.data.IMAGES' | translate }}</span>
-      <span class="d-block">{{ 'cis.report.data.NODES' | translate }}</span>
-      <span class="d-block">{{ 'cis.report.data.CONTAINERS' | translate }}</span>
+    <div class="mx-3 d-flex flex-column justify-content-around">
+      <div class="d-flex align-items-center">
+        <i class="fa fa-archive mr-2 text-info"></i>
+        <span class="text-action font-weight-bold">
+          {{ 'cis.report.data.IMAGES' | translate }}
+        </span>
+      </div>
+      <div class="d-flex align-items-center">
+        <i class="fa fa-server mr-2 text-info"></i>
+        <span class="text-action font-weight-bold">
+          {{ 'cis.report.data.NODES' | translate }}
+        </span>
+      </div>
+      <div class="d-flex align-items-center">
+        <i
+          class="far fa-square mr-2 text-info"
+          [class]="namespaceEnabled ? 'text-muted' : 'text-info'"></i>
+        <span class="text-action font-weight-bold">
+          {{ 'cis.report.data.CONTAINERS' | translate }}
+        </span>
+      </div>
     </div>
     <div class="col-1 d-flex flex-column justify-content-around">
       <span class="d-block">{{ 'cis.profile.TEMPLATES' | translate }}</span>
@@ -148,34 +165,44 @@
         <div class="margin-top-s margin-bottom-s">
           <span
             class="badge text-white"
-            style="padding-left: 3px; background-color: #64a150; max-width: 70px"
+            style="
+              padding-left: 3px;
+              background-color: #64a150;
+              max-width: 70px;
+            "
             >⋮⋮&nbsp;&nbsp;All</span
           >
         </div>
       </ng-template>
     </div>
-    <div class="col-1 d-flex flex-column justify-content-around" *appDisplayControl="'write_compliance_profile'">
+    <div
+      class="col-1 d-flex flex-column justify-content-around"
+      *appDisplayControl="'write_compliance_profile'">
       <button
         (click)="editTemplate('_images')"
         aria-label="Edit images icon button "
-        class="d-block" matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
+        class="d-block"
+        matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
         mat-icon-button>
-        <i class="eos-icons text-action">edit</i>
+        <mat-icon class="eos-icons text-action">edit</mat-icon>
       </button>
       <button
         (click)="editTemplate('_nodes')"
         aria-label="Edit nodes icon button "
-        class="d-block" matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
+        class="d-block"
+        matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
         mat-icon-button>
-        <i class="eos-icons text-action">edit</i>
+        <mat-icon class="eos-icons text-action">edit</mat-icon>
       </button>
       <button
-        (click)="editTemplate('_containers')"
+        [style.visibility]="!namespaceEnabled ? 'visible' : 'hidden'"
         [disabled]="namespaceEnabled"
+        (click)="editTemplate('_containers')"
         aria-label="Edit containers icon button "
-        class="d-block" matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
+        class="d-block"
+        matTooltip="{{ 'cis.tooltips.EDIT_TEMPLATE' | translate }}"
         mat-icon-button>
-        <i class="eos-icons text-action">edit</i>
+        <mat-icon class="eos-icons text-action">edit</mat-icon>
       </button>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.ts
@@ -132,11 +132,13 @@ export class ComplianceProfileAssetsTableComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (this.gridApi && changes.rowData) {
-      this.gridApi.setRowData(changes.rowData.currentValue);
-    }
-    if (changes.namespaceEnabled) {
-      this.toggleNamespaceActions();
+    if (this.gridApi) {
+      if (changes.rowData) {
+        this.gridApi.setRowData(changes.rowData.currentValue);
+      }
+      if (changes.namespaceEnabled && this.gridOptions) {
+        this.toggleNamespaceActions();
+      }
     }
   }
 

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/compliance-profile-assets-table.component.ts
@@ -23,6 +23,12 @@ import { ComplianceProfileService } from '@routes/compliance-profile/compliance-
 import { EditTemplateDialogComponent } from '@routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/edit-template-dialog/edit-template-dialog.component';
 import { AuthUtilsService } from '@common/utils/auth.utils';
 
+export const iconMap = {
+  _images: 'fa fa-archive',
+  _nodes: 'fa fa-server',
+  _containers: 'far fa-square',
+};
+
 @Component({
   selector: 'app-compliance-profile-assets-table',
   templateUrl: './compliance-profile-assets-table.component.html',
@@ -35,63 +41,12 @@ export class ComplianceProfileAssetsTableComponent
   @Input() imageTags!: string[];
   @Input() nodeTags!: string[];
   @Input() containerTags!: string[];
+  @Input() namespaceEnabled: boolean = false;
   gridOptions!: GridOptions;
   gridApi!: GridApi;
-  namespaceEnabled = false;
   isWriteComplianceProfileAuthorized: boolean = false;
 
-  columnDefs: ColDef[] = [
-    {
-      field: 'name',
-      sortable: true,
-      resizable: true,
-      headerValueGetter: () =>
-        this.translate.instant('cis.report.gridHeader.NAME'),
-    },
-    {
-      field: 'tags',
-      width: 120,
-      sortable: true,
-      resizable: true,
-      cellRenderer: 'templatesCellRenderer',
-      headerValueGetter: () => this.translate.instant('cis.profile.TEMPLATES'),
-    },
-    {
-      field: 'workloads',
-      width: 120,
-      sortable: true,
-      resizable: true,
-      headerValueGetter: () =>
-        this.translate.instant('multiCluster.summary.TOTAL_WORKLOAD'),
-    },
-    {
-      field: 'running_pods',
-      width: 120,
-      sortable: true,
-      resizable: true,
-      headerValueGetter: () =>
-        this.translate.instant('multiCluster.summary.RUNNING_POD'),
-    },
-    {
-      field: 'services',
-      width: 70,
-      sortable: true,
-      resizable: true,
-      headerValueGetter: () =>
-        this.translate.instant('dashboard.summary.SERVICE'),
-    },
-    {
-      field: 'action',
-      resizable: true,
-      width: 50,
-      cellRenderer: 'actionCellRenderer',
-      hide: true,
-      cellRendererParams: {
-        edit: event => this.editTemplateFromGrid(event),
-      },
-      headerValueGetter: () => this.translate.instant('setting.ACTIONS'),
-    },
-  ];
+  columnDefs!: ColDef[];
 
   constructor(
     private translate: TranslateService,
@@ -101,9 +56,67 @@ export class ComplianceProfileAssetsTableComponent
     private authUtilsService: AuthUtilsService
   ) {}
 
+  setGrid() {
+    this.columnDefs = [
+      {
+        field: 'name',
+        sortable: true,
+        resizable: true,
+        headerValueGetter: () =>
+          this.translate.instant('cis.report.gridHeader.NAME'),
+      },
+      {
+        field: 'tags',
+        width: 120,
+        sortable: true,
+        resizable: true,
+        cellRenderer: 'templatesCellRenderer',
+        headerValueGetter: () =>
+          this.translate.instant('cis.profile.TEMPLATES'),
+      },
+      {
+        field: 'workloads',
+        width: 120,
+        sortable: true,
+        resizable: true,
+        headerValueGetter: () =>
+          this.translate.instant('multiCluster.summary.TOTAL_WORKLOAD'),
+      },
+      {
+        field: 'running_pods',
+        width: 120,
+        sortable: true,
+        resizable: true,
+        headerValueGetter: () =>
+          this.translate.instant('multiCluster.summary.RUNNING_POD'),
+      },
+      {
+        field: 'services',
+        width: 70,
+        sortable: true,
+        resizable: true,
+        headerValueGetter: () =>
+          this.translate.instant('dashboard.summary.SERVICE'),
+      },
+      {
+        field: 'action',
+        resizable: true,
+        width: 50,
+        cellRenderer: 'actionCellRenderer',
+        hide:
+          !this.namespaceEnabled || !this.isWriteComplianceProfileAuthorized,
+        cellRendererParams: {
+          edit: event => this.editTemplateFromGrid(event),
+        },
+        headerValueGetter: () => this.translate.instant('setting.ACTIONS'),
+      },
+    ];
+  }
+
   ngOnInit(): void {
     this.isWriteComplianceProfileAuthorized =
       this.authUtilsService.getDisplayFlag('write_compliance_profile');
+    this.setGrid();
     this.gridOptions = {
       rowData: this.rowData,
       columnDefs: this.columnDefs,
@@ -121,6 +134,9 @@ export class ComplianceProfileAssetsTableComponent
   ngOnChanges(changes: SimpleChanges): void {
     if (this.gridApi && changes.rowData) {
       this.gridApi.setRowData(changes.rowData.currentValue);
+    }
+    if (changes.namespaceEnabled) {
+      this.toggleNamespaceActions();
     }
   }
 
@@ -192,14 +208,23 @@ export class ComplianceProfileAssetsTableComponent
     this.cd.markForCheck();
   }
 
-  enable() {
-    if (this.namespaceEnabled) {
+  toggleNamespaceActions() {
+    if (this.namespaceEnabled && this.isWriteComplianceProfileAuthorized) {
       this.gridOptions.columnApi?.setColumnVisible('action', true);
     } else {
       this.gridOptions.columnApi?.setColumnVisible('action', false);
     }
     this.gridApi.sizeColumnsToFit();
     this.cd.markForCheck();
+  }
+
+  enable() {
+    this.toggleNamespaceActions();
+    this.complianceProfileService
+      .toggleDomainTagging({
+        tag_per_domain: this.namespaceEnabled,
+      })
+      .subscribe(() => {});
   }
 
   onResize(): void {

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/edit-template-dialog/edit-template-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/edit-template-dialog/edit-template-dialog.component.html
@@ -1,46 +1,118 @@
 <div class="d-flex flex-row align-items-center justify-content-between">
-  <h1
-    class="h4">{{'cis.profile.CUSTOMIZE_TEMPLATE' | translate}}&nbsp;{{name}}</h1>
+  <h1 class="h4">
+    {{ 'cis.profile.CUSTOMIZE_TEMPLATE' | translate }}&nbsp;
+    <i class="mr-1 text-info" [class]="getAssetIcon(name)"></i>{{ name }}
+  </h1>
   <button (click)="onNoClick()" aria-label="Close dialog" mat-icon-button>
     <i class="eos-icons">close</i>
   </button>
 </div>
-<div style="height: 70px;">
-  <span class="d-block mb-2">{{'cis.profile.APPLY_REG' | translate }}</span>
+<div style="height: 70px">
+  <span class="d-block mb-2 text-success font-weight-bold">{{
+    'cis.profile.APPLY_TEMPLATES' | translate
+  }}</span>
   <ng-container *ngFor="let tag of available">
     <ng-container [ngSwitch]="tag">
-      <span *ngSwitchCase="'GDPR'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #ff9800;">⋮⋮&nbsp;&nbsp;GDPR<i
-        (click)="add('GDPR')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'HIPAA'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #4e39c1;">⋮⋮&nbsp;&nbsp;HIPAA<i
-        (click)="add('HIPAA')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'NIST'" class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
-            style="padding-left: 3px;">⋮⋮&nbsp;&nbsp;NIST<i
-        (click)="add('NIST')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'PCI'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #009688;">⋮⋮&nbsp;&nbsp;PCI<i
-        (click)="add('PCI')" class="ml-1 eos-icons" role="button">add</i></span>
+      <span
+        *ngSwitchCase="'GDPR'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #ff9800"
+        >⋮⋮&nbsp;&nbsp;GDPR<i
+          (click)="add('GDPR')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'HIPAA'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #4e39c1"
+        >⋮⋮&nbsp;&nbsp;HIPAA<i
+          (click)="add('HIPAA')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'NIST'"
+        class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
+        style="padding-left: 3px"
+        >⋮⋮&nbsp;&nbsp;NIST<i
+          (click)="add('NIST')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'PCI'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #009688"
+        >⋮⋮&nbsp;&nbsp;PCI<i
+          (click)="add('PCI')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
     </ng-container>
   </ng-container>
 </div>
-<div style="height: 70px;">
-  <span class="d-block mb-2">{{'cis.profile.CURR_TEMPLATES' | translate }}</span>
-  <span *ngIf="applied.length === 0" class="text-muted mt-2">{{'cis.profile.ADD_REG' | translate }}</span>
+<div style="height: 70px">
+  <span class="d-block mb-2 text-success font-weight-bold">{{
+    'cis.profile.CURR_TEMPLATES' | translate
+  }}</span>
+  <span *ngIf="applied.length === 0" class="text-muted mt-2">{{
+    'cis.profile.ADD_TEMPLATE' | translate
+  }}</span>
   <ng-container *ngFor="let tag of applied">
     <ng-container [ngSwitch]="tag">
-      <span *ngSwitchCase="'GDPR'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #ff9800;">⋮⋮&nbsp;&nbsp;GDPR]<i
-        (click)="remove('GDPR')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'HIPAA'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #4e39c1;">⋮⋮&nbsp;&nbsp;HIPAA<i
-        (click)="remove('HIPAA')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'NIST'" class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
-            style="padding-left: 3px;">⋮⋮&nbsp;&nbsp;NIST<i
-        (click)="remove('NIST')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'PCI'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #009688;">⋮⋮&nbsp;&nbsp;PCI<i
-        (click)="remove('PCI')" class="ml-1 eos-icons" role="button">close</i></span>
+      <span
+        *ngSwitchCase="'GDPR'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #ff9800"
+        >⋮⋮&nbsp;&nbsp;GDPR]<i
+          (click)="remove('GDPR')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'HIPAA'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #4e39c1"
+        >⋮⋮&nbsp;&nbsp;HIPAA<i
+          (click)="remove('HIPAA')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'NIST'"
+        class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
+        style="padding-left: 3px"
+        >⋮⋮&nbsp;&nbsp;NIST<i
+          (click)="remove('NIST')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'PCI'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #009688"
+        >⋮⋮&nbsp;&nbsp;PCI<i
+          (click)="remove('PCI')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
     </ng-container>
   </ng-container>
 </div>

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/edit-template-dialog/edit-template-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets-table/edit-template-dialog/edit-template-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ComplianceProfileService } from '@routes/compliance-profile/compliance-profile.service';
+import { iconMap } from '../compliance-profile-assets-table.component';
 
 @Component({
   selector: 'app-edit-template-dialog',
@@ -27,6 +28,13 @@ export class EditTemplateDialogComponent implements OnInit {
     }
     this.applied = this.data.tags || [];
     this.filterApplied();
+  }
+
+  getAssetIcon(name: string) {
+    if (name in iconMap) {
+      return iconMap[name];
+    }
+    return 'fa fa-building';
   }
 
   filterApplied() {

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets.component.html
@@ -2,6 +2,6 @@
   [containerTags]="domains.containerTags"
   [imageTags]="domains.imageTags"
   [nodeTags]="domains.nodeTags"
-  [rowData]="domains.domains">
-  
+  [rowData]="domains.domains"
+  [namespaceEnabled]="domains.tag_per_domain">
 </app-compliance-profile-assets-table>

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-assets/compliance-profile-assets.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { DomainResponse } from '../compliance-profile.service';
 
 @Component({
   selector: 'app-compliance-profile-assets',
@@ -6,7 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
   styleUrls: ['./compliance-profile-assets.component.scss'],
 })
 export class ComplianceProfileAssetsComponent implements OnInit {
-  @Input() domains!: any;
+  @Input() domains!: DomainResponse;
 
   constructor() {}
 

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/compliance-profile-templates-table.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/compliance-profile-templates-table.component.html
@@ -1,88 +1,81 @@
-<div
-  class="d-flex flex-column justify-content-between pt-2"
-  style="height: 30%">
-  <div class="d-flex flex-row justify-content-between align-items-center">
-    <div>
-      <mat-checkbox
-        (change)="updateSystem()"
-        [(ngModel)]="hideSystem"
-        *appDisplayControl="'write_compliance_profile'"
-        class="mx-3"
-        >{{ 'cis.profile.HIDE_SYSTEM' | translate }}</mat-checkbox
-      >
+<div class="d-flex flex-column justify-content-between">
+  <ng-container *appDisplayControl="'write_compliance_profile'">
+    <div
+      class="d-flex flex-row justify-content-between align-items-center pt-2">
+      <div>
+        <mat-checkbox
+          (change)="updateSystem()"
+          [(ngModel)]="hideSystem"
+          class="mx-3"
+          >{{ 'cis.profile.HIDE_SYSTEM' | translate }}</mat-checkbox
+        >
+      </div>
+      <div class="d-flex flex-row align-items-center">
+        <span *ngIf="totalChanges > 0" class="d-block"
+          >{{ totalChanges }}&nbsp;{{ 'cis.profile.PENDING' | translate
+          }}{{ 'cis.profile.CHANGES' | translate }}</span
+        >
+        <button
+          (click)="saveChanges()"
+          *ngIf="totalChanges > 0"
+          class="mx-2"
+          mat-stroked-button>
+          {{ 'general.SUBMIT' | translate }}
+        </button>
+        <button (click)="reset()" mat-stroked-button>
+          {{ 'cis.profile.RESET' | translate }}
+        </button>
+      </div>
     </div>
-    <div class="d-flex flex-row align-items-center">
-      <span *ngIf="totalChanges > 0" class="d-block"
-        >{{ totalChanges }}&nbsp;{{ 'cis.profile.PENDING' | translate
-        }}{{ 'cis.profile.CHANGES' | translate }}</span
-      >
-      <button
-        (click)="saveChanges()"
-        *ngIf="totalChanges > 0"
-        class="mx-2"
-        mat-stroked-button>
-        {{ 'general.SUBMIT' | translate }}
-      </button>
-      <button
-        (click)="reset()"
-        *appDisplayControl="'write_compliance_profile'"
-        mat-stroked-button>
-        {{ 'cis.profile.RESET' | translate }}
-      </button>
+    <div class="d-flex flex-row align-items-center cis-filter mx-3">
+      <span class="d-block mr-4">{{
+        'cis.profile.COMPLIANCE_TEMPLATE' | translate
+      }}</span>
+      <div class="d-flex flex-row align-items-center mr-2">
+        <mat-checkbox
+          (change)="filterChange('ALL')"
+          [(ngModel)]="all"
+          [disabled]="all"
+          aria-label="All"
+          class="mr-2"></mat-checkbox>
+        <span class="d-block" style="font-size: 28px; font-weight: bold"
+          >ALL</span
+        >
+      </div>
+      <div class="d-flex flex-row align-items-center">
+        <mat-checkbox
+          (change)="filterChange('PCI')"
+          [(ngModel)]="pci"
+          aria-label="PCI"
+          class="mr-2"></mat-checkbox>
+        <img alt="pci" src="assets/img/icons/pci.png" />
+      </div>
+      <div class="d-flex flex-row align-items-center mr-2">
+        <mat-checkbox
+          (change)="filterChange('GDPR')"
+          [(ngModel)]="gdpr"
+          aria-label="GDPR"
+          class="mr-2"></mat-checkbox>
+        <img alt="gdpr" src="assets/img/icons/gdpr.svg" />
+      </div>
+      <div class="d-flex flex-row align-items-center mr-2">
+        <mat-checkbox
+          (change)="filterChange('HIPAA')"
+          [(ngModel)]="hipaa"
+          aria-label="HIPAA"
+          class="mr-2"></mat-checkbox>
+        <img alt="hipaa" src="assets/img/icons/hipaa.png" />
+      </div>
+      <div class="d-flex flex-row align-items-center mr-2">
+        <mat-checkbox
+          (change)="filterChange('NIST')"
+          [(ngModel)]="nist"
+          aria-label="NIST"
+          class="mr-2"></mat-checkbox>
+        <img alt="nist" src="assets/img/icons/nist.png" />
+      </div>
     </div>
-  </div>
-  <div class="d-flex flex-row align-items-center cis-filter mx-3">
-    <span class="d-block mr-4">{{
-      'cis.profile.COMPLIANCE_TEMPLATE' | translate
-    }}</span>
-    <div class="d-flex flex-row align-items-center mr-2">
-      <mat-checkbox
-        (change)="filterChange('ALL')"
-        [(ngModel)]="all"
-        [disabled]="all || !isWriteComplianceProfileAuthorized"
-        aria-label="All"
-        class="mr-2"></mat-checkbox>
-      <span class="d-block" style="font-size: 28px; font-weight: bold"
-        >ALL</span
-      >
-    </div>
-    <div class="d-flex flex-row align-items-center">
-      <mat-checkbox
-        (change)="filterChange('PCI')"
-        [(ngModel)]="pci"
-        [disabled]="!isWriteComplianceProfileAuthorized"
-        aria-label="PCI"
-        class="mr-2"></mat-checkbox>
-      <img alt="pci" src="assets/img/icons/pci.png" />
-    </div>
-    <div class="d-flex flex-row align-items-center mr-2">
-      <mat-checkbox
-        (change)="filterChange('GDPR')"
-        [(ngModel)]="gdpr"
-        [disabled]="!isWriteComplianceProfileAuthorized"
-        aria-label="GDPR"
-        class="mr-2"></mat-checkbox>
-      <img alt="gdpr" src="assets/img/icons/gdpr.svg" />
-    </div>
-    <div class="d-flex flex-row align-items-center mr-2">
-      <mat-checkbox
-        (change)="filterChange('HIPAA')"
-        [(ngModel)]="hipaa"
-        [disabled]="!isWriteComplianceProfileAuthorized"
-        aria-label="HIPAA"
-        class="mr-2"></mat-checkbox>
-      <img alt="hipaa" src="assets/img/icons/hipaa.png" />
-    </div>
-    <div class="d-flex flex-row align-items-center mr-2">
-      <mat-checkbox
-        (change)="filterChange('NIST')"
-        [(ngModel)]="nist"
-        [disabled]="!isWriteComplianceProfileAuthorized"
-        aria-label="NIST"
-        class="mr-2"></mat-checkbox>
-      <img alt="nist" src="assets/img/icons/nist.png" />
-    </div>
-  </div>
+  </ng-container>
   <div class="d-flex flex-row justify-content-between align-items-center">
     <span class="d-block font-weight-bold text-info"
       ><span *ngIf="filtered$ | async"
@@ -104,5 +97,10 @@
   (window:resize)="onResize()"
   [gridOptions]="gridOptions"
   class="ag-theme-alpine"
-  style="width: 100%; height: 70%">
+  style="width: 100%"
+  [style.height]="
+    isWriteComplianceProfileAuthorized
+      ? 'calc(100% - 160px)'
+      : 'calc(100% - 80px)'
+  ">
 </ag-grid-angular>

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/compliance-profile-templates-table.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/compliance-profile-templates-table.component.ts
@@ -80,12 +80,13 @@ export class ComplianceProfileTemplatesTableComponent
     },
     {
       field: 'scored',
-      width: 50,
+      width: 70,
       sortable: true,
       resizable: true,
       valueFormatter: params => (params?.node?.data.scored ? 'Y' : 'N'),
       headerValueGetter: () =>
-        this.translate.instant('cis.report.gridHeader.SCORED'),
+        this.translate.instant('cis.report.gridHeader.SCORED') + '\u00A0\u24D8',
+      headerTooltip: this.translate.instant('cis.SCORED'),
     },
     {
       field: 'profile',
@@ -93,7 +94,9 @@ export class ComplianceProfileTemplatesTableComponent
       sortable: true,
       resizable: true,
       headerValueGetter: () =>
-        this.translate.instant('cis.report.gridHeader.PROFILE'),
+        this.translate.instant('cis.report.gridHeader.PROFILE') +
+        '\u00A0\u24D8',
+      headerTooltip: this.translate.instant('cis.LEVEL1'),
     },
     {
       field: 'description',
@@ -137,6 +140,7 @@ export class ComplianceProfileTemplatesTableComponent
     this.hideSystem = this.hideSystemInit;
     this.gridOptions = {
       rowData: this.rowData,
+      tooltipShowDelay: 0,
       columnDefs: this.columnDefs,
       suppressDragLeaveHidesColumns: true,
       rowSelection: 'single',

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/edit-regulation-dialog/edit-regulation-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile-templates/compliance-profile-templates-table/edit-regulation-dialog/edit-regulation-dialog.component.html
@@ -1,46 +1,115 @@
 <div class="d-flex flex-row align-items-center justify-content-between">
-  <h1
-    class="h4">Customize regulation for&nbsp;{{data.test_number}}</h1>
+  <h1 class="h4">Customize regulation for&nbsp;{{ data.test_number }}</h1>
   <button (click)="onNoClick()" aria-label="Close dialog" mat-icon-button>
     <i class="eos-icons">close</i>
   </button>
 </div>
-<div style="height: 70px;">
-  <span class="d-block mb-2">{{'cis.profile.APPLY_REG' | translate }}</span>
+<div style="height: 70px">
+  <span class="d-block mb-2 text-success font-weight-bold">{{
+    'cis.profile.APPLY_REG' | translate
+  }}</span>
   <ng-container *ngFor="let tag of available">
     <ng-container [ngSwitch]="tag">
-      <span *ngSwitchCase="'GDPR'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #ff9800;">⋮⋮&nbsp;&nbsp;GDPR<i
-        (click)="add('GDPR')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'HIPAA'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #4e39c1;">⋮⋮&nbsp;&nbsp;HIPAA<i
-        (click)="add('HIPAA')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'NIST'" class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
-            style="padding-left: 3px;">⋮⋮&nbsp;&nbsp;NIST<i
-        (click)="add('NIST')" class="ml-1 eos-icons" role="button">add</i></span>
-      <span *ngSwitchCase="'PCI'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #009688;">⋮⋮&nbsp;&nbsp;PCI<i
-        (click)="add('PCI')" class="ml-1 eos-icons" role="button">add</i></span>
+      <span
+        *ngSwitchCase="'GDPR'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #ff9800"
+        >⋮⋮&nbsp;&nbsp;GDPR<i
+          (click)="add('GDPR')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'HIPAA'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #4e39c1"
+        >⋮⋮&nbsp;&nbsp;HIPAA<i
+          (click)="add('HIPAA')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'NIST'"
+        class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
+        style="padding-left: 3px"
+        >⋮⋮&nbsp;&nbsp;NIST<i
+          (click)="add('NIST')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'PCI'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #009688"
+        >⋮⋮&nbsp;&nbsp;PCI<i
+          (click)="add('PCI')"
+          class="ml-1 eos-icons"
+          role="button"
+          >add</i
+        ></span
+      >
     </ng-container>
   </ng-container>
 </div>
-<div style="height: 70px;">
-  <span class="d-block mb-2">{{'cis.profile.CURR_REG' | translate }}</span>
-  <span *ngIf="applied.length === 0" class="text-muted mt-2">{{'cis.profile.ADD_TEMPLATE' | translate }}</span>
+<div style="height: 70px">
+  <span class="d-block mb-2 text-success font-weight-bold">{{
+    'cis.profile.CURR_REG' | translate
+  }}</span>
+  <span *ngIf="applied.length === 0" class="text-muted mt-2">{{
+    'cis.profile.ADD_TEMPLATE' | translate
+  }}</span>
   <ng-container *ngFor="let tag of applied">
     <ng-container [ngSwitch]="tag">
-      <span *ngSwitchCase="'GDPR'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #ff9800;">⋮⋮&nbsp;&nbsp;GDPR<i
-        (click)="remove('GDPR')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'HIPAA'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #4e39c1;">⋮⋮&nbsp;&nbsp;HIPAA<i
-        (click)="remove('HIPAA')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'NIST'" class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
-            style="padding-left: 3px;">⋮⋮&nbsp;&nbsp;NIST<i
-        (click)="remove('NIST')" class="ml-1 eos-icons" role="button">close</i></span>
-      <span *ngSwitchCase="'PCI'" class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
-            style="padding-left: 3px; background-color: #009688;">⋮⋮&nbsp;&nbsp;PCI<i
-        (click)="remove('PCI')" class="ml-1 eos-icons" role="button">close</i></span>
+      <span
+        *ngSwitchCase="'GDPR'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #ff9800"
+        >⋮⋮&nbsp;&nbsp;GDPR<i
+          (click)="remove('GDPR')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'HIPAA'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #4e39c1"
+        >⋮⋮&nbsp;&nbsp;HIPAA<i
+          (click)="remove('HIPAA')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'NIST'"
+        class="mr-1 d-inline-flex align-items-center badge badge-dark ml-0"
+        style="padding-left: 3px"
+        >⋮⋮&nbsp;&nbsp;NIST<i
+          (click)="remove('NIST')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
+      <span
+        *ngSwitchCase="'PCI'"
+        class="mr-1 d-inline-flex align-items-center badge text-white ml-0"
+        style="padding-left: 3px; background-color: #009688"
+        >⋮⋮&nbsp;&nbsp;PCI<i
+          (click)="remove('PCI')"
+          class="ml-1 eos-icons"
+          role="button"
+          >close</i
+        ></span
+      >
     </ng-container>
   </ng-container>
 </div>

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.html
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.html
@@ -10,7 +10,9 @@
             complianceProfileData.template.list.compliance
           "></app-compliance-profile-templates>
       </mat-tab>
-      <mat-tab [label]="'sidebar.nav.RESOURCE' | translate">
+      <mat-tab
+        [label]="'sidebar.nav.RESOURCE' | translate"
+        *ngIf="!isNamespaceUser">
         <app-compliance-profile-assets
           [domains]="
             complianceProfileData.domains

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.ts
@@ -3,6 +3,7 @@ import {
   ComplianceProfileData,
   ComplianceProfileTemplateData,
 } from '@common/types';
+import { AuthUtilsService } from '@common/utils/auth.utils';
 import {
   ComplianceProfileService,
   DomainResponse,
@@ -23,10 +24,14 @@ export class ComplianceProfileComponent implements OnInit, OnDestroy {
     domains: DomainResponse;
   };
   loaded = false;
+  get isNamespaceUser() {
+    return this.authUtilsService.userPermission.isNamespaceUser;
+  }
 
   constructor(
     private complianceProfileService: ComplianceProfileService,
-    private multiClusterService: MultiClusterService
+    private multiClusterService: MultiClusterService,
+    private authUtilsService: AuthUtilsService
   ) {}
 
   ngOnInit(): void {

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.component.ts
@@ -2,9 +2,11 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
   ComplianceProfileData,
   ComplianceProfileTemplateData,
-  DomainGetResponse,
 } from '@common/types';
-import { ComplianceProfileService } from '@routes/compliance-profile/compliance-profile.service';
+import {
+  ComplianceProfileService,
+  DomainResponse,
+} from '@routes/compliance-profile/compliance-profile.service';
 import { MultiClusterService } from '@services/multi-cluster.service';
 import { Subscription } from 'rxjs';
 
@@ -18,7 +20,7 @@ export class ComplianceProfileComponent implements OnInit, OnDestroy {
   complianceProfileData!: {
     template: ComplianceProfileTemplateData;
     profile: ComplianceProfileData;
-    domains: DomainGetResponse;
+    domains: DomainResponse;
   };
   loaded = false;
 

--- a/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.service.ts
+++ b/admin/webapp/websrc/app/routes/compliance-profile/compliance-profile.service.ts
@@ -11,6 +11,12 @@ import {
 } from '@common/types';
 import { MapConstant } from '@common/constants/map.constant';
 
+export interface DomainResponse extends DomainGetResponse {
+  imageTags: string[];
+  containerTags: string[];
+  nodeTags: string[];
+}
+
 @Injectable()
 export class ComplianceProfileService {
   private resizeSubject$ = new BehaviorSubject<boolean>(true);
@@ -71,6 +77,10 @@ export class ComplianceProfileService {
     return this.assetsHttpService.patchDomain(payload);
   }
 
+  toggleDomainTagging(payload) {
+    return this.assetsHttpService.postDomain(payload);
+  }
+
   private getTemplate(): Observable<ComplianceProfileTemplateData> {
     return this.risksHttpService.getComplianceProfileTemplate().pipe(
       catchError(err => {
@@ -103,9 +113,10 @@ export class ComplianceProfileService {
     );
   }
 
-  private getDomain(): Observable<DomainGetResponse> {
+  private getDomain(): Observable<DomainResponse> {
     return this.assetsHttpService.getDomain().pipe(
-      map(res => {
+      map(domainRes => {
+        let res: DomainResponse = domainRes as any;
         res['imageTags'] =
           res.domains.find(item => item.name === '_images')?.tags || [];
         res['containerTags'] =
@@ -126,6 +137,7 @@ export class ComplianceProfileService {
             imageTags: [],
             containerTags: [],
             nodeTags: [],
+            tag_per_domain: false,
           } as any);
         } else {
           throw err;

--- a/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.html
+++ b/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.html
@@ -61,7 +61,9 @@
           class="mr-3"
           (click)="scan.emit(selectedContainer)"
           [disabled]="
-            !selectedContainer || selectedContainer.brief.state === 'exit'
+            !isScannerInstalled ||
+            !selectedContainer ||
+            selectedContainer.brief.state === 'exit'
           ">
           {{ 'scan.SCAN' | translate }}
         </button>

--- a/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/containers-grid/containers-grid.component.ts
@@ -54,6 +54,9 @@ export class ContainersGridComponent implements OnInit {
       this.containersService.displayContainers
     ).length;
   }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
+  }
   get cisLabel() {
     return this.utils.getCisLabel(this.versionInfoService.infoData);
   }

--- a/admin/webapp/websrc/app/routes/components/controllers-grid/controllers-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/controllers-grid/controllers-grid.component.ts
@@ -145,6 +145,7 @@ export class ControllersGridComponent implements OnInit, OnChanges {
 
   refresh(): void {
     this.refreshing$.next(true);
+    this.selectedControllerSubject$.next(undefined);
     this.getControllers();
   }
 

--- a/admin/webapp/websrc/app/routes/components/enforcers-grid/enforcers-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/enforcers-grid/enforcers-grid.component.ts
@@ -181,6 +181,7 @@ export class EnforcersGridComponent implements OnInit, OnChanges {
 
   refresh(): void {
     this.refreshing$.next(true);
+    this.selectedEnforcerSubject$.next(undefined);
     this.getEnforcers();
   }
 

--- a/admin/webapp/websrc/app/routes/components/events-grid/csv-generation/events-grid-csv.service.ts
+++ b/admin/webapp/websrc/app/routes/components/events-grid/csv-generation/events-grid-csv.service.ts
@@ -23,7 +23,6 @@ export class EventsGridCsvService {
     events4Csv = events4Csv.map(event => {
       this.eventRow2Item(event);
       if (!event.enforcer_limit) event.enforcer_limit = 0;
-      if (!event.license_expire) event.license_expire = '';
       if (event.user_roles) {
         event.user_roles = JSON.stringify(event.user_roles).replace(/\"/g, "'");
       }

--- a/admin/webapp/websrc/app/routes/components/nodes-grid/nodes-grid.component.html
+++ b/admin/webapp/websrc/app/routes/components/nodes-grid/nodes-grid.component.html
@@ -55,7 +55,7 @@
           type="button"
           class="mr-3"
           (click)="scan.emit(selectedNode)"
-          [disabled]="!selectedNode">
+          [disabled]="!isScannerInstalled || !selectedNode">
           {{ 'scan.SCAN' | translate }}
         </button>
       </ng-container>

--- a/admin/webapp/websrc/app/routes/components/nodes-grid/nodes-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/nodes-grid/nodes-grid.component.ts
@@ -45,6 +45,9 @@ export class NodesGridComponent implements OnInit {
   get nodesCount() {
     return this.nodesService.nodes.length;
   }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
+  }
   get cisLabel() {
     return this.utils.getCisLabel(this.versionInfoService.infoData);
   }

--- a/admin/webapp/websrc/app/routes/components/platforms-grid/platforms-grid.component.html
+++ b/admin/webapp/websrc/app/routes/components/platforms-grid/platforms-grid.component.html
@@ -1,6 +1,5 @@
-<div
-  class="d-flex align-items-center justify-content-between">
-<div class="d-flex align-items-center justify-content-start">
+<div class="d-flex align-items-center justify-content-between">
+  <div class="d-flex align-items-center justify-content-start">
     <span class="font-weight-bold text-info">
       <span *ngIf="filtered">
         {{ 'enum.FOUND' | translate }}
@@ -9,27 +8,27 @@
       <span *ngIf="!filtered"> {{ 'enum.OUT_OF' | translate }}&nbsp; </span>
       {{ platformsCount }}
     </span>
-</div>
-<div class="d-flex align-items-center justify-content-end">
-  <div *ngIf="isScanAuthorized">
-    <ng-container *ngIf="selectedPlatform$ | async as selectedPlatform">
-      <button
-        mat-stroked-button
-        aria-label="Scan action"
-        type="button"
-        class="mr-3"
-        (click)="scan.emit(selectedPlatform)"
-        [disabled]="!selectedPlatform">
-        {{ 'scan.SCAN' | translate }}
-      </button>
-    </ng-container>
   </div>
-  <app-quick-filter
-    [gridOptions]="gridOptions"
-    (filterCountChange)="filterCountChanged($event)"
-    [showCount]="false">
-  </app-quick-filter>
-</div>
+  <div class="d-flex align-items-center justify-content-end">
+    <div *ngIf="isScanAuthorized">
+      <ng-container *ngIf="selectedPlatform$ | async as selectedPlatform">
+        <button
+          mat-stroked-button
+          aria-label="Scan action"
+          type="button"
+          class="mr-3"
+          (click)="scan.emit(selectedPlatform)"
+          [disabled]="!isScannerInstalled || !selectedPlatform">
+          {{ 'scan.SCAN' | translate }}
+        </button>
+      </ng-container>
+    </div>
+    <app-quick-filter
+      [gridOptions]="gridOptions"
+      (filterCountChange)="filterCountChanged($event)"
+      [showCount]="false">
+    </app-quick-filter>
+  </div>
 </div>
 <ag-grid-angular
   (window:resize)="onResize()"

--- a/admin/webapp/websrc/app/routes/components/platforms-grid/platforms-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/platforms-grid/platforms-grid.component.ts
@@ -4,6 +4,7 @@ import { GlobalConstant } from '@common/constants/global.constant';
 import { MapConstant } from '@common/constants/map.constant';
 import { Platform } from '@common/types';
 import { UtilsService } from '@common/utils/app.utils';
+import { GlobalVariable } from '@common/variables/global.variable';
 import { TranslateService } from '@ngx-translate/core';
 import { PlatformsService } from '@services/platforms.service';
 import {
@@ -38,6 +39,9 @@ export class PlatformsGridComponent implements OnInit {
     this.selectedPlatformSubject$.asObservable();
   get platformsCount() {
     return this.platformsService.platforms.length;
+  }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
   }
   columnDefs: ColDef[] = [
     {

--- a/admin/webapp/websrc/app/routes/components/scanners-grid/scanners-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/scanners-grid/scanners-grid.component.ts
@@ -132,6 +132,7 @@ export class ScannersGridComponent implements OnInit, OnChanges {
 
   refresh(): void {
     this.refreshing$.next(true);
+    this.selectedScannerSubject$.next(undefined);
     this.getScanners();
   }
 

--- a/admin/webapp/websrc/app/routes/components/security-risk-panel/partial/vulnerability-instruction/vulnerability-instruction.component.html
+++ b/admin/webapp/websrc/app/routes/components/security-risk-panel/partial/vulnerability-instruction/vulnerability-instruction.component.html
@@ -1,7 +1,14 @@
-<div *ngIf="dashboardDetailsService.isAutoScanOn then vulnerabilityInstruction; else autoScanRequest"></div>
+<div
+  *ngIf="
+    dashboardDetailsService.isAutoScanOn;
+    then vulnerabilityInstruction;
+    else autoScanRequest
+  "></div>
 
 <ng-template #vulnerabilityInstruction>
-  <div *ngIf="dashboardDetailsService.isAutoScanOn">{{ 'dashboard.heading.guideline.VUL_EXPLOIT' | translate }}</div>
+  <div *ngIf="dashboardDetailsService.isAutoScanOn">
+    {{ 'dashboard.heading.guideline.VUL_EXPLOIT' | translate }}
+  </div>
 </ng-template>
 
 <ng-template #autoScanRequest>
@@ -12,11 +19,10 @@
     </div>
     <div class="text-center margin-top-s">
       <mat-slide-toggle
-        [disabled]="!isAutoScanAuthorized"
+        [disabled]="!isAutoScanAuthorized || !isScannerInstalled"
         [(ngModel)]="isAutoScanOn"
-        (change)="turnOnAutoScan()"
-      >
-        {{'scan.AUTO' | translate}}
+        (change)="turnOnAutoScan()">
+        {{ 'scan.AUTO' | translate }}
       </mat-slide-toggle>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/components/security-risk-panel/partial/vulnerability-instruction/vulnerability-instruction.component.ts
+++ b/admin/webapp/websrc/app/routes/components/security-risk-panel/partial/vulnerability-instruction/vulnerability-instruction.component.ts
@@ -3,25 +3,30 @@ import { AuthUtilsService } from '@common/utils/auth.utils';
 import { DashboardDetailsService } from '@routes/dashboard/thread-services/dashboard-details.service';
 import { DashboardService } from '@services/dashboard.service';
 import { MapConstant } from '@common/constants/map.constant';
+import { GlobalVariable } from '@common/variables/global.variable';
 
 @Component({
   selector: 'app-vulnerability-instruction',
   templateUrl: './vulnerability-instruction.component.html',
-  styleUrls: ['./vulnerability-instruction.component.scss']
+  styleUrls: ['./vulnerability-instruction.component.scss'],
 })
 export class VulnerabilityInstructionComponent implements OnInit {
-
-  isAutoScanAuthorized: boolean;
-  isAutoScanOn: boolean;
+  isAutoScanAuthorized!: boolean;
+  isAutoScanOn!: boolean;
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
+  }
 
   constructor(
     private authUtilsService: AuthUtilsService,
     public dashboardDetailsService: DashboardDetailsService,
     private dashboardService: DashboardService
-  ) { }
+  ) {}
 
   ngOnInit(): void {
-    this.isAutoScanAuthorized = this.authUtilsService.getDisplayFlag("runtime_scan") && !this.authUtilsService.userPermission.isNamespaceUser;
+    this.isAutoScanAuthorized =
+      this.authUtilsService.getDisplayFlag('runtime_scan') &&
+      !this.authUtilsService.userPermission.isNamespaceUser;
   }
 
   turnOnAutoScan = () => {
@@ -49,5 +54,4 @@ export class VulnerabilityInstructionComponent implements OnInit {
       }
     );
   };
-
 }

--- a/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.ts
+++ b/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.ts
@@ -147,6 +147,8 @@ export class ContainerDetailsComponent implements OnInit, OnDestroy {
         },
         error: ({ error }: { error: ErrorResponse }) => {
           console.error(error);
+          this.containerCompliance = { items: [] } as any;
+          this.complianceEmpty = true;
         },
       });
   }
@@ -169,6 +171,8 @@ export class ContainerDetailsComponent implements OnInit, OnDestroy {
       },
       error: ({ error }: { error: ErrorResponse }) => {
         console.error(error);
+        this.containerVuls = [];
+        this.vulEmpty = true;
       },
     });
   }

--- a/admin/webapp/websrc/app/routes/containers/containers.component.html
+++ b/admin/webapp/websrc/app/routes/containers/containers.component.html
@@ -11,6 +11,7 @@
       <ng-container *ngIf="!error">
         <div class="mr-3" *ngIf="autoScanAuthorized && containers.length > 0">
           <mat-slide-toggle
+            [disabled]="!isScannerInstalled"
             [formControl]="autoScan"
             (change)="configAutoScan(auto_scan)">
             {{ 'scan.AUTO' | translate }}

--- a/admin/webapp/websrc/app/routes/containers/containers.component.ts
+++ b/admin/webapp/websrc/app/routes/containers/containers.component.ts
@@ -13,6 +13,7 @@ import { MultiClusterService } from '@services/multi-cluster.service';
 import { ScanService } from '@services/scan.service';
 import { interval, Subject } from 'rxjs';
 import { finalize, takeUntil } from 'rxjs/operators';
+import { GlobalVariable } from '@common/variables/global.variable';
 
 @Component({
   selector: 'app-containers',
@@ -54,6 +55,9 @@ export class ContainersComponent implements OnInit {
   }
   get containers() {
     return this.containersService.containers;
+  }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
   }
 
   constructor(

--- a/admin/webapp/websrc/app/routes/nodes/nodes.component.html
+++ b/admin/webapp/websrc/app/routes/nodes/nodes.component.html
@@ -7,6 +7,7 @@
       <ng-container *ngIf="!error">
         <div class="mr-3" *ngIf="autoScanAuthorized && nodes.length > 0">
           <mat-slide-toggle
+            [disabled]="!isScannerInstalled"
             [formControl]="autoScan"
             (change)="configAutoScan(auto_scan)">
             {{ 'scan.AUTO' | translate }}

--- a/admin/webapp/websrc/app/routes/nodes/nodes.component.ts
+++ b/admin/webapp/websrc/app/routes/nodes/nodes.component.ts
@@ -18,6 +18,7 @@ import { ScanService } from '@services/scan.service';
 import { interval, Subject } from 'rxjs';
 import { finalize, takeUntil } from 'rxjs/operators';
 import { MultiClusterService } from '@services/multi-cluster.service';
+import { GlobalVariable } from '@common/variables/global.variable';
 
 @Component({
   selector: 'app-nodes',
@@ -36,6 +37,9 @@ export class NodesComponent implements OnInit {
   }
   get nodesGrid() {
     return this._nodesGrid;
+  }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
   }
   refreshing$ = new Subject();
   error!: string;

--- a/admin/webapp/websrc/app/routes/platforms/platforms.component.html
+++ b/admin/webapp/websrc/app/routes/platforms/platforms.component.html
@@ -7,6 +7,7 @@
       <ng-container *ngIf="!error">
         <div class="mr-3" *ngIf="autoScanAuthorized && platforms.length > 0">
           <mat-slide-toggle
+            [disabled]="!isScannerInstalled"
             [formControl]="autoScan"
             (change)="configAutoScan(auto_scan)">
             {{ 'scan.AUTO' | translate }}

--- a/admin/webapp/websrc/app/routes/platforms/platforms.component.ts
+++ b/admin/webapp/websrc/app/routes/platforms/platforms.component.ts
@@ -19,6 +19,7 @@ import { ScanService } from '@services/scan.service';
 import { interval, Subject } from 'rxjs';
 import { finalize, takeUntil } from 'rxjs/operators';
 import { MultiClusterService } from '@services/multi-cluster.service';
+import { GlobalVariable } from '@common/variables/global.variable';
 
 @Component({
   selector: 'app-platforms',
@@ -39,6 +40,9 @@ export class PlatformsComponent implements OnInit, OnDestroy {
   }
   get platformsGrid() {
     return this._platformsGrid;
+  }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
   }
   refreshing$ = new Subject();
   error!: string;

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.html
@@ -33,6 +33,7 @@
     [appearance]="'mat-stroked-button'"
     [buttonClasses]="'mr-2'"
     [disabled]="
+      !isScannerInstalled ||
       (gridApi && !gridApi.getSelectedNodes().length) ||
       (gridApi &&
         gridApi.getSelectedNodes().length &&
@@ -50,6 +51,7 @@
     *appDisplayControl="'registry_scan'"
     [appearance]="'mat-stroked-button'"
     [disabled]="
+      !isScannerInstalled ||
       (gridApi && !gridApi.getSelectedNodes().length) ||
       (gridApi &&
         gridApi.getSelectedNodes().length &&

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
@@ -146,6 +146,9 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
   get isFedAdmin() {
     return GlobalVariable.user.token.role === MapConstant.FED_ROLES.FEDADMIN;
   }
+  get isScannerInstalled() {
+    return GlobalVariable.summary.scanners !== 0;
+  }
 
   constructor(
     private dialog: MatDialog,

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/config-constants.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/config-constants.ts
@@ -349,8 +349,7 @@ export const DurationSliderField = {
   hooks: {
     onInit: field => {
       const ctrl = field.parent.formControl.get('duration_toggle');
-      field.templateOptions.disabled =
-        !field.formControl.value || field.formControl.disabled;
+      field.templateOptions.disabled = !ctrl.value || ctrl.disabled;
       ctrl.valueChanges.subscribe(isEnabled => {
         field.templateOptions.onChangeDisabled(!isEnabled);
       });

--- a/admin/webapp/websrc/app/routes/system-components/controller-details/controller-details.component.ts
+++ b/admin/webapp/websrc/app/routes/system-components/controller-details/controller-details.component.ts
@@ -19,7 +19,7 @@ export class ControllerDetailsComponent implements OnInit, OnDestroy {
   @ViewChild('detailsTabGroup', { static: false })
   detailsTabGroup!: MatTabGroup;
   activeTabIndex: number = 0;
-  currentController!: Controller;
+  currentController!: Controller | undefined;
   totalPoints = 30;
   cpuChartData!: ChartConfiguration<'line', number[], string>;
   cpuData!: ComponentChartData;
@@ -46,12 +46,11 @@ export class ControllerDetailsComponent implements OnInit, OnDestroy {
     this.cpuChartData = this.getCPUConfig();
     this.componentsCommunicationService.selectedController$.subscribe(
       controller => {
-        if (controller) {
-          this.currentController = controller;
-          this.clearCharts();
-          if (this.activeTabIndex === 1 && this.chart.chart) {
-            this.getStats();
-          }
+        this.currentController = controller;
+        if (!this.currentController) return;
+        this.clearCharts();
+        if (this.activeTabIndex === 1 && this.chart.chart) {
+          this.getStats();
         }
       }
     );

--- a/admin/webapp/websrc/app/routes/system-components/enforcer-details/enforcer-details.component.ts
+++ b/admin/webapp/websrc/app/routes/system-components/enforcer-details/enforcer-details.component.ts
@@ -18,7 +18,7 @@ export class EnforcerDetailsComponent implements OnInit, OnDestroy {
   @ViewChild('detailsTabGroup', { static: false })
   detailsTabGroup!: MatTabGroup;
   activeTabIndex: number = 0;
-  currentEnforcer!: Enforcer;
+  currentEnforcer!: Enforcer | undefined;
   get isDisconnected() {
     return this.currentEnforcer?.connection_state === 'disconnected';
   }
@@ -40,18 +40,17 @@ export class EnforcerDetailsComponent implements OnInit, OnDestroy {
     this.initTabs();
     this.componentsCommunicationService.selectedEnforcer$.subscribe(
       enforcer => {
-        if (enforcer) {
-          this.currentEnforcer = enforcer;
-          if (this.containerStats) {
-            this.containerStats.clearCharts();
-          }
-          if (
-            this.activeTabIndex === 1 &&
-            this.containerStats.charts.length > 0 &&
-            this.containerStats.charts.toArray().every(c => c.chart)
-          ) {
-            this.getStats();
-          }
+        this.currentEnforcer = enforcer;
+        if (!this.currentEnforcer) return;
+        if (this.containerStats) {
+          this.containerStats.clearCharts();
+        }
+        if (
+          this.activeTabIndex === 1 &&
+          this.containerStats.charts.length > 0 &&
+          this.containerStats.charts.toArray().every(c => c.chart)
+        ) {
+          this.getStats();
         }
       }
     );

--- a/admin/webapp/websrc/app/routes/system-components/scanner-details/scanner-details.component.ts
+++ b/admin/webapp/websrc/app/routes/system-components/scanner-details/scanner-details.component.ts
@@ -9,7 +9,7 @@ import { SystemComponentsCommunicationService } from '../system-components-commu
   styleUrls: ['./scanner-details.component.scss'],
 })
 export class ScannerDetailsComponent implements OnInit {
-  currentScanner!: Scanner;
+  currentScanner!: Scanner | undefined;
   activeScannerSub!: Subscription;
 
   constructor(
@@ -18,9 +18,7 @@ export class ScannerDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.componentsCommunicationService.selectedScanner$.subscribe(scanner => {
-      if (scanner) {
-        this.currentScanner = scanner;
-      }
+      this.currentScanner = scanner;
     });
   }
 }

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import {
   ErrorResponse,
+  Vulnerability,
   VulnerabilityAsset,
   VulnerabilityProfile,
 } from '@common/types';
@@ -32,6 +33,7 @@ import { VulnerabilityItemsTableFilterComponent } from './vulnerability-items-ta
 import { DatePipe } from '@angular/common';
 import { UtilsService } from '@common/utils/app.utils';
 import { NotificationService } from '@services/notification.service';
+import { GlobalVariable } from '@common/variables/global.variable';
 
 @Component({
   selector: 'app-vulnerability-items-table',
@@ -138,7 +140,7 @@ export class VulnerabilityItemsTableComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.gridOptions = {
-      headerHeight:  30,
+      headerHeight: 30,
       rowHeight: 30,
       rowData: this.rowData,
       columnDefs: this.columnDefs,
@@ -164,7 +166,9 @@ export class VulnerabilityItemsTableComponent implements OnInit, OnDestroy {
         {
           name: this.selectedVulnerability.name,
           days: 0,
-          comment: `Accepted by ${'REPLACE WITH USER'} at ${this.datePipe.transform(
+          comment: `Accepted by ${
+            GlobalVariable.user.token.username
+          } at ${this.datePipe.transform(
             new Date(),
             'MMM dd, y HH:mm:ss'
           )} from Vulnerabilities page`,
@@ -176,6 +180,11 @@ export class VulnerabilityItemsTableComponent implements OnInit, OnDestroy {
     };
     this.vulnerabilitiesService.acceptVulnerability(payload).subscribe({
       complete: () => {
+        this.rowData = this.rowData.filter(
+          vul => vul.name !== this.selectedVulnerability.name
+        );
+        this.gridApi.setRowData(this.rowData);
+        this.gridApi.getDisplayedRowAtIndex(0)?.setSelected(true);
         this.notificationService.open(
           this.translate.instant('cveProfile.msg.ADD_OK')
         );
@@ -319,7 +328,7 @@ export class VulnerabilityItemsTableComponent implements OnInit, OnDestroy {
 
   onGridReady(params: GridReadyEvent): void {
     this.gridApi = params.api;
-    this.vulnerabilitiesService.gridApi = this.gridApi
+    this.vulnerabilitiesService.gridApi = this.gridApi;
     this.changeScoreView(this.vulnerabilitiesFilterService.selectedScore);
     this.gridApi.sizeColumnsToFit();
     this.gridApi.forEachNode(node =>

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
@@ -120,6 +120,7 @@ export class VulnerabilityItemsTableComponent implements OnInit, OnDestroy {
     {
       resizable: true,
       cellRenderer: 'csvCellRenderer',
+      cellClass: ['d-flex', 'align-items-center'],
       headerValueGetter: () => 'CSV',
       width: 80,
       maxWidth: 80,


### PR DESCRIPTION
Addresses:
- NVSHAS-7392: Secrisk>Vulnern Not autohide acpted entry creates multiple vulnprof entries
- NVSHAS-6766: NV-5.1 ContainerScan exported Vuln. csv report missing in_base_image column
- NVSHAS-7201: Secrisk>Comprof > Ass-user(view+mod. permissions) diff. strings used
- NVSHAS-7343: Notification>Events Export shows "license_expire" column
- NVSHAS-7165: ComplianceViewUser>SecriskCompProfile>>TEMPLATES unfocus tab & shows Compliance Filter
- NVSHAS-7146: No rows is shown in assets > containers > compliance/vuln/process tab if security event(R) namespace user is logged in
- NVSHAS-7174: fedreader can move the auto deletion bar
- NVSHAS-7320: [Manager] Under Security Risks --> Compliance Profile using "confignsr" custom user, "Assets" tab should not be shown
- NVSHAS-7367: [Scanner] Do not allow user to "Start scan" without NeuVector scanner container installed on allinone machine