### PR TITLE
NVSHAS-6695: Expose namespace label in REST API

### DIFF
--- a/cli/prog/domain.py
+++ b/cli/prog/domain.py
@@ -11,6 +11,14 @@ def _list_domain_display_format(d):
     f = "tags"
     if d.get(f):
         d[output.key_output(f)] = ",".join(d[f])
+    f = "labels"
+    if d.get(f):
+        fo = output.key_output(f)
+        kv = ""
+        keys = sorted(d[f].keys())
+        for key in keys:
+            kv += "%s=%s\n" % (key, d[f][key])
+        d[fo] = kv.rstrip("\n")
 
 
 @show.command("domain")
@@ -29,7 +37,7 @@ def show_domain(ctx, data, page):
         for domain in domains:
             _list_domain_display_format(domain)
 
-        columns = ("name", "workloads", "running_pods", "services", "tags")
+        columns = ("name", "workloads", "running_pods", "services", "tags", "labels")
         output.list(columns, domains)
 
         if args["limit"] > 0 and len(domains) < args["limit"]:


### PR DESCRIPTION
Append Nameapce's labels via a REST API call: GET "/v1/domain"

(1) Add REST entry:
type RESTDomain struct {
.........
Labels map[string]string json:"labels"
}

(2) Update CLI response: "show domain".

(3) Update swagger data.