### PR TITLE
NVSHAS-7335: Allow NeuVector to set several ADFS certificates in parallel in x.509 certificate field.

### DIFF
--- a/admin/src/main/scala/com/neu/model/AuthTokenJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/AuthTokenJsonProtocol.scala
@@ -43,7 +43,7 @@ object AuthTokenJsonProtocol extends DefaultJsonProtocol {
 
   implicit val groupMappedRoleFormat: RootJsonFormat[GroupMappedRole] = jsonFormat3(GroupMappedRole)
   implicit val ldapServerFormat: RootJsonFormat[LdapServer]           = jsonFormat12(LdapServer)
-  implicit val samlServerFormat: RootJsonFormat[SamlServer]           = jsonFormat7(SamlServer)
+  implicit val samlServerFormat: RootJsonFormat[SamlServer]           = jsonFormat8(SamlServer)
   implicit val ssoServerFormat: RootJsonFormat[SsoServer]             = jsonFormat3(SsoServer)
   implicit val samlTokenFormat: RootJsonFormat[SamlToken]             = jsonFormat3(SamlToken)
   implicit val samlResponseFormat: RootJsonFormat[SamlResponse]       = jsonFormat3(SamlResponse)

--- a/admin/src/main/scala/com/neu/model/SamlServer.scala
+++ b/admin/src/main/scala/com/neu/model/SamlServer.scala
@@ -7,6 +7,7 @@ case class SamlServer(
   sso_url: String,
   issuer: String,
   x509_cert: Option[String],
+  x509_cert_extras: Option[Array[String]],
   group_claim: Option[String] = Some(""),
   enable: Option[Boolean],
   default_role: Option[String],

--- a/admin/webapp/websrc/app/common/types/settings/settings.ts
+++ b/admin/webapp/websrc/app/common/types/settings/settings.ts
@@ -83,6 +83,7 @@ export interface SAML {
   sso_url: string;
   issuer: string;
   x509_cert: string;
+  x509_cert_extras: string[];
   group_claim: string;
   default_role: string;
   group_mapped_roles: GroupMappedRole[];

--- a/admin/webapp/websrc/app/routes/settings/saml/saml-form/saml-form.component.html
+++ b/admin/webapp/websrc/app/routes/settings/saml/saml-form/saml-form.component.html
@@ -20,8 +20,7 @@
         <input
           formControlName="sso_url"
           matInput
-          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate"
-        />
+          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate" />
         <mat-error *ngIf="samlForm.controls.sso_url.hasError('required')">
           {{ 'general.REQUIRED' | translate }}
         </mat-error>
@@ -37,8 +36,7 @@
         <input
           formControlName="issuer"
           matInput
-          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate"
-        />
+          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate" />
         <mat-error *ngIf="samlForm.controls.issuer.hasError('required')">
           {{ 'general.REQUIRED' | translate }}
         </mat-error>
@@ -64,6 +62,35 @@
         </mat-error>
       </mat-form-field>
     </div>
+    <ng-container formArrayName="x509_cert_extras">
+      <div
+        *ngFor="let _ of x509_extras.controls; let i = index"
+        class="col-12 d-flex align-items-center">
+        <i class="eos-icons mr-3 text-primary invisible">verified</i>
+        <mat-form-field appearance="standard" class="w-100">
+          <mat-label>{{ 'okta.EXTRA_CERT' | translate }}</mat-label>
+          <textarea
+            cdkTextareaAutosize
+            [formControlName]="i"
+            matInput></textarea>
+        </mat-form-field>
+        <button
+          (click)="removeExtraCert(i)"
+          aria-label="Remove extra X509_cert"
+          type="button"
+          mat-icon-button>
+          <mat-icon>delete_forever</mat-icon>
+        </button>
+      </div>
+    </ng-container>
+    <div
+      class="col-12 d-flex align-items-center"
+      *ngIf="samlForm.get('x509_cert')?.value && x509_extras.length < 3">
+      <button (click)="addExtraCert()" type="button" mat-stroked-button>
+        <i class="eos-icons mr-2 icon-16">add_circle</i>
+        {{ 'okta.ADD_EXTRA_CERT' | translate }}
+      </button>
+    </div>
     <div class="col-12 d-flex align-items-center">
       <i class="eos-icons mr-3 text-primary">groups</i>
       <mat-form-field appearance="standard" class="w-100">
@@ -71,8 +98,7 @@
         <input
           formControlName="group_claim"
           matInput
-          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate"
-        />
+          [attr.maxlength]="'general.FILTER_MAX_LEN' | translate" />
       </mat-form-field>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/settings/saml/saml-form/saml-form.component.scss
+++ b/admin/webapp/websrc/app/routes/settings/saml/saml-form/saml-form.component.scss
@@ -4,3 +4,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
 }
+
+.icon-16 {
+  font-size: 16px;
+}

--- a/admin/webapp/websrc/app/routes/settings/saml/saml.module.ts
+++ b/admin/webapp/websrc/app/routes/settings/saml/saml.module.ts
@@ -14,6 +14,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { SettingsService } from '@services/settings.service';
+import { MatIconModule } from '@angular/material/icon';
 
 const routes: Routes = [
   { path: '', component: SamlComponent },
@@ -31,6 +32,7 @@ const routes: Routes = [
     MatInputModule,
     MatCheckboxModule,
     MatButtonModule,
+    MatIconModule,
     MatCardModule,
     MatSelectModule,
     ClipboardModule,

--- a/admin/webapp/websrc/assets/i18n/en.json
+++ b/admin/webapp/websrc/assets/i18n/en.json
@@ -3048,6 +3048,8 @@
     "IDP_URL": "Identity Provider Single Sign-On URL",
     "IDP_ISSUER": "Identity Provider Issuer",
     "CERTIFICATE": "X.509 Certificate",
+    "ADD_EXTRA_CERT": "Add extra X.509 Certificate",
+    "EXTRA_CERT": "Extra X.509 Certificate",
     "INVALID_URL": "Please input valid url.",
     "GROUP_CLAIM": "Group Claim",
     "ADMIN_HINT": "Add SAML groups which map to NeuVector admin",

--- a/admin/webapp/websrc/assets/i18n/zh_cn.json
+++ b/admin/webapp/websrc/assets/i18n/zh_cn.json
@@ -3048,6 +3048,8 @@
     "IDP_URL": "身份提供者单点登录网址",
     "IDP_ISSUER": "身份提供者",
     "CERTIFICATE": "X.509证书",
+    "ADD_EXTRA_CERT": "添加额外的X.509证书",
+    "EXTRA_CERT": "额外的X.509证书",
     "INVALID_URL": "请输入有效的网址.",
     "GROUP_CLAIM": "组别声明",
     "ADMIN_HINT": "添加SAML组到管理员",


### PR DESCRIPTION
Adds UI support for SAML config field `x509_cert_extras`. References neuvector/neuvector#678