### PR TITLE
NVSHAS-7629: jFrog registry filter test throws error

### DIFF
--- a/admin/webapp/websrc/app/common/types/registries/registries.ts
+++ b/admin/webapp/websrc/app/common/types/registries/registries.ts
@@ -25,6 +25,7 @@ export interface RegistryConfig {
   auth_with_token: boolean;
   password?: string;
   username?: string;
+  jfrog_mode?: string;
   gitlab_external_url?: string;
   gitlab_private_token?: string;
   ibm_cloud_account?: string;

--- a/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/test-connection-dialog/test-settings-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/add-registry-dialog/test-connection-dialog/test-settings-dialog.component.ts
@@ -108,6 +108,7 @@ export class TestSettingsDialogComponent implements OnInit, OnDestroy {
       filters: this.form.controls.filters.value,
       username: this.data.username,
       password: this.data.password,
+      jfrog_mode: this.data.jfrog_mode,
       auth_token: this.data.auth_token,
       auth_with_token: this.data.auth_with_token,
       scan_layers: this.data.scan_layers,


### PR DESCRIPTION
Adds missing `jfrog_mode` field to Registry test payload