### PR TITLE
Aarch64 support

### DIFF
--- a/Dockerfile.manager
+++ b/Dockerfile.manager
@@ -13,7 +13,7 @@ LABEL name="manager" \
       neuvector.role="manager" \
       neuvector.rev="git.xxxx"
 
-RUN adduser -S manager
+RUN useradd manager
 USER manager
 
 ENTRYPOINT ["java", "-Xms256m", "-Xmx2048m", "-Djdk.tls.rejectClientInitiatedRenegotiation=true", "-jar", "/usr/local/bin/admin-assembly-1.0.jar"]

--- a/share/fsmon/fanotify_arm64.go
+++ b/share/fsmon/fanotify_arm64.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2012, Moritz Bitsch <moritzbitsch@googlemail.com>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+package fsmon
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Add/Delete/Modify an Fanotify mark
+func (nd *NotifyFD) Mark(flags int, mask uint64, dfd int, path string) error {
+	_, _, errno := syscall.Syscall6(syscall.SYS_FANOTIFY_MARK, uintptr(nd.f.Fd()), uintptr(flags), uintptr(mask), uintptr(dfd), uintptr(unsafe.Pointer(syscall.StringBytePtr(path))), 0)
+
+	var err error
+	if errno != 0 {
+		err = errno
+	}
+
+	return err
+}


### PR DESCRIPTION
Hello,
This series enables AArch64 support in Neuvector.

Taken directly from fanotify_amd64.go. Syscall numbers for arm64 are
supplied separately.

adduser was not available in the OS image, switch to the commonly
available useradd instead.

Note that we are pushing a few pull requests to different Neuvector repos. For testing purposes, all these should be considered together.
Cheers, Dean