### PR TITLE
NVSHAS-8475 Indicate if the service is vulnerable in dashboard ingress/egress exposure section

### DIFF
--- a/admin/webapp/websrc/app/common/types/dashboard/dashboard.ts
+++ b/admin/webapp/websrc/app/common/types/dashboard/dashboard.ts
@@ -146,7 +146,7 @@ export interface ExposedContainer {
   severity: string;
 }
 
-export interface ConversationReportEntryByServce {
+export interface ConversationReportEntryByService {
   ip: string;
   fqdn?: string;
   protocols: string[];
@@ -173,6 +173,6 @@ export interface HierarchicalExposure {
   protocols: string;
   applications: string[];
   ports: number[];
-  entries: ConversationReportEntryByServce[];
+  entries: ConversationReportEntryByService[];
   children: ExposedContainer[];
 }

--- a/admin/webapp/websrc/app/common/utils/common.utils.ts
+++ b/admin/webapp/websrc/app/common/utils/common.utils.ts
@@ -13,7 +13,7 @@ import {
   WorkloadChildV2,
   DataOps,
   WorkloadV2,
-  ConversationReportEntryByServce,
+  ConversationReportEntryByService,
 } from '@common/types';
 import { WorkloadBrief } from '@common/types/compliance/workloadBrief';
 import { GridApi, GridOptions } from 'ag-grid-community';
@@ -666,6 +666,8 @@ export const parseExposureHierarchicalData = (
 
   Object.entries(groupedExposure).forEach(([k, v]) => {
     let applicationSet = new Set<string>();
+    let total_high_vuls_by_service = 0;
+    let total_medium_vuls_by_service = 0;
     v.forEach(child => {
       if (child.applications) {
         child.applications.forEach(app => {
@@ -677,6 +679,8 @@ export const parseExposureHierarchicalData = (
           applicationSet.add(port as any);
         });
       }
+      total_high_vuls_by_service += child.high;
+      total_medium_vuls_by_service += child.medium;
     });
     let hierarchicalExposure: HierarchicalExposure = {
       workload_id: '',
@@ -687,8 +691,8 @@ export const parseExposureHierarchicalData = (
       bytes: 0,
       sessions: 0,
       severity: '',
-      high: v[0].high,
-      medium: v[0].medium,
+      high: total_high_vuls_by_service,
+      medium: total_medium_vuls_by_service,
       policy_action: v[0].policy_action,
       event_type: '',
       protocols: '',
@@ -748,7 +752,7 @@ const summarizeEntries = exposedPods => {
       }
     });
   });
-  return Object.values(entryMap) as ConversationReportEntryByServce[];
+  return Object.values(entryMap) as ConversationReportEntryByService[];
 };
 
 export const accumulateActionLevel = (

--- a/admin/webapp/websrc/app/routes/components/exposed-servicepod-conv-grid/conversation-entry-list/conversation-entry-list.component.ts
+++ b/admin/webapp/websrc/app/routes/components/exposed-servicepod-conv-grid/conversation-entry-list/conversation-entry-list.component.ts
@@ -2,19 +2,19 @@ import { Component, OnInit } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 import { MapConstant } from '@common/constants/map.constant';
-import { ConversationReportEntryByServce } from '@common/types';
+import { ConversationReportEntryByService } from '@common/types';
 
 @Component({
   selector: 'app-conversation-entry-list',
   templateUrl: './conversation-entry-list.component.html',
-  styleUrls: ['./conversation-entry-list.component.scss']
+  styleUrls: ['./conversation-entry-list.component.scss'],
 })
-export class ConversationEntryListComponent implements ICellRendererAngularComp {
-
+export class ConversationEntryListComponent
+  implements ICellRendererAngularComp
+{
   params: ICellRendererParams;
   colourMap: any = MapConstant.colourMap;
-  conversationEntryList: Array<ConversationReportEntryByServce>
-
+  conversationEntryList: Array<ConversationReportEntryByService>;
 
   agInit(params: ICellRendererParams): void {
     this.params = params;
@@ -24,5 +24,4 @@ export class ConversationEntryListComponent implements ICellRendererAngularComp 
   refresh(params: ICellRendererParams): boolean {
     return false;
   }
-
 }


### PR DESCRIPTION
fixed an issue: 
When a service exists across multiple pods, and each pod has vulnerabilities, the overall vulnerability of the service should be the aggregate of all these pod's vulnerability number.