### PR TITLE
NVSHAS-9122,NVSHAS-9213,NVSHAS-9214,NVSHAS-9217,NVSHAS-7522

### DIFF
--- a/admin/src/main/scala/com/neu/api/AuthenticationService.scala
+++ b/admin/src/main/scala/com/neu/api/AuthenticationService.scala
@@ -996,7 +996,7 @@ class AuthenticationService()(implicit executionContext: ExecutionContext)
                 }
               } else if (e.getMessage.contains("Status: 410")) {
                 Utils.respondWithWebServerHeaders() {
-                  complete((StatusCodes.Gone, "Please Login from Rancher again!"))
+                  complete((StatusCodes.Gone, "Please logout and then login from Rancher again!"))
                 }
               } else {
                 logger.warn(e.getClass.toString)
@@ -1015,7 +1015,9 @@ class AuthenticationService()(implicit executionContext: ExecutionContext)
                       }
                     } else if (e.getMessage.contains("Status: 410")) {
                       Utils.respondWithWebServerHeaders() {
-                        complete((StatusCodes.Gone, "Please Login from Rancher again!"))
+                        complete(
+                          (StatusCodes.Gone, "Please logout and then login from Rancher again!")
+                        )
                       }
                     } else {
                       Utils.respondWithWebServerHeaders() {

--- a/admin/src/main/scala/com/neu/api/AuthenticationService.scala
+++ b/admin/src/main/scala/com/neu/api/AuthenticationService.scala
@@ -994,6 +994,10 @@ class AuthenticationService()(implicit executionContext: ExecutionContext)
                 Utils.respondWithWebServerHeaders() {
                   onUnauthorized(e)
                 }
+              } else if (e.getMessage.contains("Status: 410")) {
+                Utils.respondWithWebServerHeaders() {
+                  complete((StatusCodes.Gone, "Please Login from Rancher again!"))
+                }
               } else {
                 logger.warn(e.getClass.toString)
                 reloadCtrlIp()
@@ -1008,6 +1012,10 @@ class AuthenticationService()(implicit executionContext: ExecutionContext)
                           )) {
                       Utils.respondWithWebServerHeaders() {
                         onUnauthorized(e)
+                      }
+                    } else if (e.getMessage.contains("Status: 410")) {
+                      Utils.respondWithWebServerHeaders() {
+                        complete((StatusCodes.Gone, "Please Login from Rancher again!"))
                       }
                     } else {
                       Utils.respondWithWebServerHeaders() {

--- a/admin/src/main/scala/com/neu/api/RiskService.scala
+++ b/admin/src/main/scala/com/neu/api/RiskService.scala
@@ -52,7 +52,7 @@ class RiskService()(implicit executionContext: ExecutionContext)
                 complete {
                   logger.info(s"Getting scanned assets ...")
                   RestClient.httpRequestWithHeader(
-                    s"${baseClusterUri(tokenId)}/scan/asset/view/asset",
+                    s"${baseClusterUri(tokenId)}/scan/asset/images",
                     POST,
                     scannedAssetsQueryToJson(
                       scannedAssetsQuery
@@ -75,7 +75,7 @@ class RiskService()(implicit executionContext: ExecutionContext)
               Utils.respondWithWebServerHeaders() {
                 complete {
                   val url =
-                    s"${baseClusterUri(tokenId)}/scan/asset/view/asset?token=$token&start=$start&row=$row${if (orderby.isDefined)
+                    s"${baseClusterUri(tokenId)}/scan/asset/images?token=$token&start=$start&row=$row${if (orderby.isDefined)
                       s"&orderby=${orderby.get}"
                     else ""}${if (orderbyColumn.isDefined)
                       s"&orderbyColumn=${orderbyColumn.get}"

--- a/admin/webapp/websrc/app/core/interceptor/timeout.interceptor.ts
+++ b/admin/webapp/websrc/app/core/interceptor/timeout.interceptor.ts
@@ -49,7 +49,9 @@ export class TimeoutInterceptor implements HttpInterceptor {
             (status === GlobalConstant.STATUS_SERVER_UNAVAILABLE &&
               currentPath !== GlobalConstant.PATH_LOGIN &&
               currentPath !== '/' + GlobalConstant.PATH_LOGIN &&
-              currentPath !== GlobalConstant.PATH_MULTICLUSTER) ||
+              currentPath !== GlobalConstant.PATH_MULTICLUSTER &&
+              !req.url.endsWith(PathConstant.MULTI_CLUSTER_SUMMARY)
+            ) ||
             req.url === PathConstant.TOKEN_AUTH ||
             req.url === PathConstant.SELF_URL
           ) {

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.html
@@ -32,7 +32,7 @@
   class="ag-theme-alpine"
   style="width: 100%">
 </ag-grid-angular>
-<div class="d-flex align-items-center justify-content-end mt-2">
+<div class="d-flex align-items-center justify-content-end mt-2" *ngIf="!registriesCommunicationService.selectedRegistry?.isAllView">
   <app-loading-button
     (btnClick)="startScan()"
     [appearance]="'mat-stroked-button'"

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
@@ -178,7 +178,7 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
     private dialog: MatDialog,
     private translate: TranslateService,
     private registriesService: RegistriesService,
-    private registriesCommunicationService: RegistriesCommunicationService,
+    public registriesCommunicationService: RegistriesCommunicationService,
     private cd: ChangeDetectorRef,
     private authUtilsService: AuthUtilsService,
     private notificationService: NotificationService,

--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -9,6 +9,8 @@ common {
     new.ctrl.key = "/etc/neuvector/certs/ssl-cert.key"
     new.cert = "/etc/neuvector/certs/ssl-cert.pem"
     new.key = "/etc/neuvector/certs/ssl-cert.key"
+    new.mgr.cert = "/tmp/ssl-cert-m.pem"
+    new.mgr.key = "/tmp/ssl-cert-m.key"
   }
 
   cassandra {

--- a/common/src/main/scala/com/neu/core/CommonSettings.scala
+++ b/common/src/main/scala/com/neu/core/CommonSettings.scala
@@ -23,6 +23,8 @@ object CommonSettings extends LazyLogging {
   val trustStore: String  = config.getString("rest.trust.store")
   val newCert: String     = config.getString("rest.new.cert")
   val newKey: String      = config.getString("rest.new.key")
+  val newMgrCert: String  = config.getString("rest.new.mgr.cert")
+  val newMgrKey: String   = config.getString("rest.new.mgr.key")
   val newCtrlCert: String = config.getString("rest.new.ctrl.cert")
   val newCtrlKey: String  = config.getString("rest.new.ctrl.key")
 


### PR DESCRIPTION
NVSHAS-9122: Neuvector master logs out any time use "Multiple Cluster" using Rancher SSO login
NVSHAS-9213: scan result cannot be displayed in UI after click View all scanned images in NV UI registries page
NVSHAS-9214: Prompt user to re-login Rancher Console when NV controller gets 410 from Rancher API server for SSO
NVSHAS-9217: Manager exception
NVSHAS-7522: Easy Image navigation through registries (Easy Image navigation through registries(REST API URL changed))