### PR TITLE
NVSHAS-9239: Global Notification Rbac notification should not disappear if the accept operation is not successful.

### DIFF
--- a/admin/webapp/websrc/app/common/types/common/common.ts
+++ b/admin/webapp/websrc/app/common/types/common/common.ts
@@ -64,7 +64,14 @@ export function isErrorResponse(err: ErrorResponse): err is ErrorResponse {
   return 'code' in err && 'error' in err && 'message' in err;
 }
 
+export enum GlobalNotificationType {
+  RBAC_NOTIFICATION = 'RBAC_NOTIFICATION',
+  MANAGER_NOTIFICATION = 'MANAGER_NOTIFICATION',
+  USER_NOTIFICATION = 'USER_NOTIFICATION'
+}
+
 export interface GlobalNotification {
+  type: GlobalNotificationType;
   name: string;
   key: string;
   message: string;
@@ -72,7 +79,6 @@ export interface GlobalNotification {
   labelClass: string;
   accepted: boolean;
   unClamped: boolean;
-  isRbacNotification: boolean;
 }
 
 export interface GlobalNotificationPayLoad {

--- a/admin/webapp/websrc/app/common/types/common/common.ts
+++ b/admin/webapp/websrc/app/common/types/common/common.ts
@@ -72,6 +72,7 @@ export interface GlobalNotification {
   labelClass: string;
   accepted: boolean;
   unClamped: boolean;
+  isRbacNotification: boolean;
 }
 
 export interface GlobalNotificationPayLoad {

--- a/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.html
+++ b/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.html
@@ -21,7 +21,7 @@
       <em
         class="fa fa-circle mx-3"
         [class]="'text-' + notification.labelClass"></em>
-      <ng-container *ngIf="isRbacNotif(notification.name); else globalNotif">
+      <ng-container *ngIf="isRbacNotif(notification); else globalNotif">
         <span
           class="notification-message"
           [class]="notification.unClamped ? 'unclamped' : 'clamped'"


### PR DESCRIPTION
1. Revised to use the enum type for the reduction of the free typing string of the code, and gaining some more resilient usages.

Objects:
```
export enum GlobalNotificationType {
  RBAC_NOTIFICATION = 'RBAC_NOTIFICATION',
  MANAGER_NOTIFICATION = 'MANAGER_NOTIFICATION',
  USER_NOTIFICATION = 'USER_NOTIFICATION'
}

export interface GlobalNotification {
  type: GlobalNotificationType;
  name: string;
  key: string;
  message: string;
  link: string;
  labelClass: string;
  accepted: boolean;
  unClamped: boolean;
}
```

Data initialization (GlobalNotification):
```
if (this.rbacData.acceptable_alerts) {
      Object.keys(this.rbacData.acceptable_alerts).forEach(rbacAlertType => {
        const alert = this.rbacData.acceptable_alerts[rbacAlertType];
        if (alert && Object.keys(alert).length > 0) {
          Object.keys(alert).forEach(key => {
            this.globalNotifications.push({
              type: GlobalNotificationType.RBAC_NOTIFICATION,
              name: rbacAlertType + ':' + alert[key],
              key: key,
              message: alert[key],
              link: '',
              labelClass: 'danger',
              accepted: this.rbacData.accepted_alerts
                ? this.rbacData.accepted_alerts.includes(key)
                : false,
              unClamped: false,
            });
          });
        }
      });
    }
```

Check functions: 
```
isRbacNotif(notification: GlobalNotification) {
    return notification.type === GlobalNotificationType.RBAC_NOTIFICATION;
  }

  isManagerNotif(notification: GlobalNotification) {
    return notification.type === GlobalNotificationType.MANAGER_NOTIFICATION;
  }

  isUserNotif(notification: GlobalNotification) {
    return notification.type === GlobalNotificationType.USER_NOTIFICATION;
```

2. Added getRBACAndCheckNotificationAccepted(notification: GlobalNotification) function for inquiry the RBAC data again, for checking if the  RBAC notification is accepted successfully. (We can consider whether to keep it or not, if the frontend can make sure the effects of operations will be exactly the same as the backend, then I think we totally do not need this.)