### PR TITLE
NVSHAS-8539 Reconfig proxy setting lose password

### DIFF
--- a/admin/src/main/scala/com/neu/model/SystemConfig.scala
+++ b/admin/src/main/scala/com/neu/model/SystemConfig.scala
@@ -5,6 +5,16 @@ package com.neu.model
  */
 case class RegistyHttpProxy(url: String, username: String, password: Option[String])
 case class RegistyHttpsProxy(url: String, username: String, password: Option[String])
+case class RegistyHttpProxyCfg(
+  url: Option[String],
+  username: Option[String],
+  password: Option[String]
+)
+case class RegistyHttpsProxyCfg(
+  url: Option[String],
+  username: Option[String],
+  password: Option[String]
+)
 case class Webhook(
   name: String,
   url: String,
@@ -107,7 +117,9 @@ case class SystemConfigProxyCfgV2(
   registry_http_proxy_status: Option[Boolean] = None,
   registry_https_proxy_status: Option[Boolean] = None,
   registry_http_proxy: Option[RegistyHttpProxy] = None,
-  registry_https_proxy: Option[RegistyHttpsProxy] = None
+  registry_https_proxy: Option[RegistyHttpsProxy] = None,
+  registry_http_proxy_cfg: Option[RegistyHttpProxyCfg] = None,
+  registry_https_proxy_cfg: Option[RegistyHttpsProxyCfg] = None
 )
 
 case class SystemConfigIBMSAVCfg2(

--- a/admin/src/main/scala/com/neu/model/SystemConfigJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/SystemConfigJsonProtocol.scala
@@ -13,6 +13,12 @@ object SystemConfigJsonProtocol extends DefaultJsonProtocol {
   implicit val registyHttpProxyFormat: RootJsonFormat[RegistyHttpProxy] = jsonFormat3(
     RegistyHttpProxy
   )
+  implicit val registyHttpsProxyCfgFormat: RootJsonFormat[RegistyHttpsProxyCfg] = jsonFormat3(
+    RegistyHttpsProxyCfg
+  )
+  implicit val registyHttpProxyCfgFormat: RootJsonFormat[RegistyHttpProxyCfg] = jsonFormat3(
+    RegistyHttpProxyCfg
+  )
   implicit val githubConfigurationFormat: RootJsonFormat[GithubConfiguration] = jsonFormat6(
     GithubConfiguration
   )
@@ -53,7 +59,7 @@ object SystemConfigJsonProtocol extends DefaultJsonProtocol {
   implicit val systemConfigAuthCfgV2Format: RootJsonFormat[SystemConfigAuthCfgV2] = jsonFormat3(
     SystemConfigAuthCfgV2
   )
-  implicit val systemConfigProxyCfgV2Format: RootJsonFormat[SystemConfigProxyCfgV2] = jsonFormat4(
+  implicit val systemConfigProxyCfgV2Format: RootJsonFormat[SystemConfigProxyCfgV2] = jsonFormat6(
     SystemConfigProxyCfgV2
   )
   implicit val systemConfigIBMSAVCfg2Format: RootJsonFormat[SystemConfigIBMSAVCfg2] = jsonFormat2(

--- a/admin/webapp/websrc/app/common/types/settings/config.ts
+++ b/admin/webapp/websrc/app/common/types/settings/config.ts
@@ -7,13 +7,13 @@ import {
 
 export interface ConfigResponse
   extends SvcConfig,
-  SyslogConfig,
-  AuthConfig,
-  ProxyConfig,
-  IBMSAConfig,
-  MiscConfig,
-  AtmoConfig,
-  NetConfig {
+    SyslogConfig,
+    AuthConfig,
+    ProxyConfig,
+    IBMSAConfig,
+    MiscConfig,
+    AtmoConfig,
+    NetConfig {
   scanner_autoscale: ScannerAutoscale;
   webhooks: Webhook[];
   duration_toggle?: boolean;
@@ -85,8 +85,10 @@ export interface AuthConfig {
 
 export interface ProxyConfig {
   registry_http_proxy: Proxy;
+  registry_http_proxy_cfg: Proxy;
   registry_http_proxy_status: boolean;
   registry_https_proxy: Proxy;
+  registry_https_proxy_cfg: Proxy;
   registry_https_proxy_status: boolean;
 }
 

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
@@ -9,11 +9,7 @@ import {
 import { FormGroup } from '@angular/forms';
 import { GlobalConstant } from '@common/constants/global.constant';
 import { MapConstant } from '@common/constants/map.constant';
-import {
-  ConfigPatch,
-  ErrorResponse,
-  IBMSetupGetResponse,
-} from '@common/types';
+import { ConfigPatch, ErrorResponse, IBMSetupGetResponse } from '@common/types';
 import { UtilsService } from '@common/utils/app.utils';
 import { AuthUtilsService } from '@common/utils/auth.utils';
 import { GlobalVariable } from '@common/variables/global.variable';
@@ -34,7 +30,6 @@ import { ConfigV2Vo } from '@common/types/settings/config-vo';
   styleUrls: ['./config-form.component.scss'],
 })
 export class ConfigFormComponent implements OnInit {
-
   private _config!: ConfigV2Vo;
 
   ibmSetup!: IBMSetupGetResponse;
@@ -123,7 +118,7 @@ export class ConfigFormComponent implements OnInit {
       isRegHttpsProxyAuthorized: isSettingAuth,
       isConfigAuthorized: isSettingAuth,
       isIBMSAAuthorized: isSettingAuth,
-      isTlsAuthorized: isSettingAuth
+      isTlsAuthorized: isSettingAuth,
     };
     this.serverErrorMessage = '';
     this.cd.detectChanges();
@@ -219,14 +214,18 @@ export class ConfigFormComponent implements OnInit {
           rancher_ep: base_config.auth.rancher_ep,
         },
         proxy_cfg: {
-          registry_http_proxy: base_config.proxy.registry_http_proxy.password
+          registry_http_proxy: base_config.proxy.registry_http_proxy,
+          registry_https_proxy: base_config.proxy.registry_https_proxy,
+          registry_http_proxy_cfg: base_config.proxy.registry_http_proxy
+            .password
             ? base_config.proxy.registry_http_proxy
             : Object.assign({}, base_config.proxy.registry_http_proxy, {
                 password: null,
               }),
           registry_http_proxy_status:
             base_config.proxy.registry_http_proxy_status,
-          registry_https_proxy: base_config.proxy.registry_https_proxy.password
+          registry_https_proxy_cfg: base_config.proxy.registry_https_proxy
+            .password
             ? base_config.proxy.registry_https_proxy
             : Object.assign({}, base_config.proxy.registry_https_proxy, {
                 password: null,
@@ -261,8 +260,8 @@ export class ConfigFormComponent implements OnInit {
         },
         tls_cfg: {
           enable_tls_verification: base_config.tls['enable_tls_verification'],
-          cacerts: base_config.tls['cacerts'].map(c => c.context)
-        }
+          cacerts: base_config.tls['cacerts'].map(c => c.context),
+        },
       },
     };
   }


### PR DESCRIPTION
Problem
To fix NVSHAS-8539 "Reconfig proxy setting lose password", 'registry_http(s)_proxy_cfg' has been added to 'RESTSystemConfigProxyCfgV2', UI must update the payload structure when calling the '/v2/system/config' patch endpoint to ensure that the proxy settings are correctly updated on the configuration page without losing the password.

Solution
When the UI calls the '/v2/system/config' patch endpoint, it sends a payload with 'config_v2.proxy_cfg.registry_http_proxy_cfg.password' and 'config_v2.proxy_cfg.registry_https_proxy_cfg.password' set to null to save the proxy settings without modifying the existing passwords.

