### PR TITLE
NVSHAS-9297 raw permission string is displayed on SSO UI

### DIFF
--- a/admin/webapp/websrc/assets/i18n/en-common.json
+++ b/admin/webapp/websrc/assets/i18n/en-common.json
@@ -1971,6 +1971,7 @@
       "COMPLIANCE": "Compliance",
       "CONFIG": "System Config",
       "VULNERABILITY": "Vulnerability",
+      "FED": "Federation",
       "description": {
         "AUDIT_EVENTS": "Access risk and compliance event logs.",
         "EVENTS": "Access system activity event logs.",
@@ -1984,7 +1985,8 @@
         "CI_SCAN": "Trigger build-phase vulnerability scan.",
         "COMPLIANCE": "Review Compliance check results, manage compliance profile and configure custom compliance scripts.",
         "CONFIG": "Manage system configurations.",
-        "VULNERABILITY": "Review and configure vulnerability management profile."
+        "VULNERABILITY": "Review and configure vulnerability management profile.",
+        "FED": "Manage multiple clusters."
       }
     }
   },

--- a/admin/webapp/websrc/assets/i18n/zh_cn-common.json
+++ b/admin/webapp/websrc/assets/i18n/zh_cn-common.json
@@ -1971,6 +1971,7 @@
       "COMPLIANCE": "合规",
       "CONFIG": "系统配置",
       "VULNERABILITY": "漏洞",
+      "FED": "多集群",
       "description": {
         "AUDIT_EVENTS": "访问风险和合规事件日志.",
         "EVENTS": "访问系统活动事件日志.",
@@ -1984,7 +1985,8 @@
         "CI_SCAN": "触发构筑阶段漏洞扫描.",
         "COMPLIANCE": "浏览合规检查结果, 管理合规资料和配置自定义合规脚本.",
         "CONFIG": "管理系统配置",
-        "VULNERABILITY": "浏览和配置漏洞管理资料"
+        "VULNERABILITY": "浏览和配置漏洞管理资料",
+        "FED": "管理多集群"
       }
     }
   },


### PR DESCRIPTION
Problem:
The settings->Users page displays the raw string "role.permissions.FED" instead of a translated label.

Solution:
Added a translation entry for the "FED" permission ID in the i18n files.