### PR TITLE
NVSHAS-9352 NV Rancher SSO user with fed(r/w)+regscan(r/w) permissions can click 'Add Webhook' button on top-right icon -> Federated Policy -> Webhooks page

### DIFF
--- a/admin/webapp/websrc/app/routes/components/federated-policy-configuration/federated-config-form/federated-config-form.component.ts
+++ b/admin/webapp/websrc/app/routes/components/federated-policy-configuration/federated-config-form/federated-config-form.component.ts
@@ -67,6 +67,7 @@ export class FederatedConfigFormComponent
 
   ngOnInit(): void {
     this.isFedOpAllowed =
+      this.authUtilsService.getDisplayFlag('write_config') &&
       this.authUtilsService.getDisplayFlag('multi_cluster_w');
     this.fedConfigOptions.formState.permissions = {
       isWebhookAuthorized: this.isFedOpAllowed,


### PR DESCRIPTION
Problem:
A user with 'fed' ( read & write) and 'regscan' (read & write) permissions in NV Rancher SSO should not be able to add a webhook on the "Federation Policy-> Webhook" page.

Solution:
Implemented the missing authentication check for "config_w" to ensure proper authorization.