### PR TITLE
NVSHAS-9258: remove redirect link of tls self-signed cert expiring alert, use NV docs' instructions instead

### DIFF
--- a/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts
+++ b/admin/webapp/websrc/app/routes/components/global-notifications/global-notifications.component.ts
@@ -379,7 +379,6 @@ export class GlobalNotificationsComponent implements OnInit {
       let severity: SystemAlertSeverity = SystemAlertSeverity.INFO;
 
       if(type === SystemAlertType.TLS_CERTIFICATE) {
-        link = '#/settings/configuration';
         severity = SystemAlertSeverity.WARNING;
       } else if(type === SystemAlertType.RBAC) {
         severity = SystemAlertSeverity.CRITICAL;


### PR DESCRIPTION
<img width="559" alt="Manager, Controller, Enforcer are" src="https://github.com/user-attachments/assets/c4ac81dc-8479-4408-86ab-6e3ecf16e044">
