### PR TITLE
NVSHAS-9373, NVSHAS-9374, NVSHAS-9378, NVSHAS-9385 and NVSHAS-9386

### DIFF
--- a/admin/webapp/websrc/app/common/utils/auth.utils.ts
+++ b/admin/webapp/websrc/app/common/utils/auth.utils.ts
@@ -22,11 +22,13 @@ export class AuthUtilsService {
   }
 
   private parseGlobalPermission(g_permissions) {
-    return g_permissions?.map(permission => {
-      return `${permission.id}_${
-        permission.write ? 'w' : permission.read ? 'r' : ''
-      }`;
-    }) ?? [];
+    return (
+      g_permissions?.map(permission => {
+        return `${permission.id}_${
+          permission.write ? 'w' : permission.read ? 'r' : ''
+        }`;
+      }) ?? []
+    );
   }
 
   private parseDomainPermission(d_permission: Map<string, Array<Permission>>) {
@@ -92,7 +94,7 @@ export class AuthUtilsService {
       let domainPermissions = this.parseDomainPermission(
         GlobalVariable.user.domain_permissions
       );
-      
+
       GlobalVariable.namespaces4NamespaceUser =
         this.getNamespaces4NamespaceUser(
           GlobalVariable.user.domain_permissions
@@ -146,10 +148,14 @@ export class AuthUtilsService {
     if (GlobalVariable.user) {
       let ownedPermissions;
 
-      if(!GlobalVariable.isRemote || this.isFedPermission(this.getCacheUserPermission().globalPermissions)) {
+      if (
+        !GlobalVariable.isRemote ||
+        this.isFedRole(GlobalVariable.user.token?.role)
+      ) {
         ownedPermissions = this.getCacheUserPermission().ownedPermissions;
       } else {
-        ownedPermissions = this.getCacheUserPermission().remoteGlobalPermissions;
+        ownedPermissions =
+          this.getCacheUserPermission().remoteGlobalPermissions;
       }
 
       if (ownedPermissions.length > 0) {
@@ -188,10 +194,16 @@ export class AuthUtilsService {
     if (GlobalVariable.user) {
       let ownedPermissions = [];
 
-      if (!GlobalVariable.isRemote || this.isFedPermission(this.getCacheUserPermission().globalPermissions)) {
-        ownedPermissions = isWithDomainPermission ? this.getCacheUserPermission().ownedPermissions : this.getCacheUserPermission().globalPermissions;
+      if (
+        !GlobalVariable.isRemote ||
+        this.isFedRole(GlobalVariable.user.token?.role)
+      ) {
+        ownedPermissions = isWithDomainPermission
+          ? this.getCacheUserPermission().ownedPermissions
+          : this.getCacheUserPermission().globalPermissions;
       } else {
-        ownedPermissions = this.getCacheUserPermission().remoteGlobalPermissions;
+        ownedPermissions =
+          this.getCacheUserPermission().remoteGlobalPermissions;
       }
       console.log(
         'ownedPermissions:',
@@ -210,12 +222,18 @@ export class AuthUtilsService {
 
   hasExtraPermission(tokenInfo) {
     return (
-      tokenInfo.extra_permissions && Array.isArray(tokenInfo.extra_permissions) && tokenInfo.extra_permissions.length > 0 ||
-      tokenInfo.extra_permissions_domains && Object.keys(tokenInfo.extra_permissions_domains).length > 0
+      (tokenInfo.extra_permissions &&
+        Array.isArray(tokenInfo.extra_permissions) &&
+        tokenInfo.extra_permissions.length > 0) ||
+      (tokenInfo.extra_permissions_domains &&
+        Object.keys(tokenInfo.extra_permissions_domains).length > 0)
     );
   }
 
-  private isFedPermission(permissions: any): boolean {
-    return permissions?.find(p => (p as string).startsWith('fed_'));
+  private isFedRole(role: string | null): boolean {
+    if (!role) {
+      return false;
+    }
+    return role.toLowerCase().includes('fed');
   }
 }

--- a/admin/webapp/websrc/app/routes/components/admission-rules/admission-rules.component.html
+++ b/admin/webapp/websrc/app/routes/components/admission-rules/admission-rules.component.html
@@ -38,7 +38,7 @@
                 mat-menu-item
                 class="d-flex align-items-center"
                 (click)="showAdvancedSetting()"
-                *ngIf="globalStatus">
+                *ngIf="globalStatus && isWriteAdmissionRuleAuthorized">
                 <em class="eos-icons mr-2">config_map</em>
                 {{ 'admissionControl.GLOBAL_OPS' | translate }}
               </button>

--- a/admin/webapp/websrc/app/routes/components/admission-rules/admission-rules.component.ts
+++ b/admin/webapp/websrc/app/routes/components/admission-rules/admission-rules.component.ts
@@ -155,7 +155,9 @@ export class AdmissionRulesComponent implements OnInit {
           this.filteredCount = this.admissionRules.length;
 
           this.canConfig =
-            state.state!.cfg_type !== GlobalConstant.CFG_TYPE.GROUND;
+            state.state == null
+              ? false
+              : state.state.cfg_type !== GlobalConstant.CFG_TYPE.GROUND;
           this.isK8s = state.k8s_env;
           if (!this.canConfig) {
             this.stateWarning = this.translate.instant(

--- a/admin/webapp/websrc/app/routes/groups-page/groups-page.component.ts
+++ b/admin/webapp/websrc/app/routes/groups-page/groups-page.component.ts
@@ -86,10 +86,12 @@ export class GroupsPageComponent implements OnInit {
   };
 
   private getConfig = () => {
+    console.log('in group page');
     this.groupsService.getConfigData().subscribe(
       response => {
         this.netServiceStatus = response.net_svc.net_service_status;
-        this.netServicePolicyModeValue = response.net_svc.net_service_policy_mode.toLowerCase();
+        this.netServicePolicyModeValue =
+          response.net_svc.net_service_policy_mode.toLowerCase();
         this.netServicePolicyMode = this.translate.instant(
           `enum.${response.net_svc.net_service_policy_mode.toUpperCase()}`
         );

--- a/admin/webapp/websrc/app/routes/groups-page/groups-page.component.ts
+++ b/admin/webapp/websrc/app/routes/groups-page/groups-page.component.ts
@@ -86,12 +86,10 @@ export class GroupsPageComponent implements OnInit {
   };
 
   private getConfig = () => {
-    console.log('in group page');
     this.groupsService.getConfigData().subscribe(
       response => {
         this.netServiceStatus = response.net_svc.net_service_status;
-        this.netServicePolicyModeValue =
-          response.net_svc.net_service_policy_mode.toLowerCase();
+        this.netServicePolicyModeValue = response.net_svc.net_service_policy_mode.toLowerCase();
         this.netServicePolicyMode = this.translate.instant(
           `enum.${response.net_svc.net_service_policy_mode.toUpperCase()}`
         );


### PR DESCRIPTION
[NVSHAS-9373] NV SSO user with fed(r)+admissioncontrol(r) permissions can click Test in admission control page on managed cluster UI

[NVSHAS-9374] NV SSO user with fed(r)+non-admissioncontrol(r) permissions see "Loading" in admission control page on master cluster UI

[NVSHAS-9378] NV SSO user with fed(r)+registryscan/authentication/authorization(r/w) permissions unexpectedly can click 'Edit/Delete/Start Scan' of non-fed registry & 'Add/Edit/Delete' buttons of many pages on managed cluster

[NVSHAS-9386]NV SSO user with fed(r)+ all permission resources except cluster/namespace(r/w) permissions unexpectedly can edit LDAP & Password Profile pages on managed cluster

[NVSHAS-9385]NV SSO user with fed(r)+vulnerability/compliance/runtimepolicy/runtimescan/systemconfig(r/w) permissions unexpectedly can click 'Add/Edit/Delete/Scan' buttons of many pages on managed cluster