### PR TITLE
NVSHAS-9537: Change existing builders base image to BCI for AMD64 - m…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 STAGE_DIR = stage
 BASE_IMAGE_TAG = latest
-BUILD_IMAGE_TAG = latest
+BUILD_IMAGE_TAG = v3
 
 copy_mgr:
 	cp manager/licenses/* ${STAGE_DIR}/licenses/


### PR DESCRIPTION
…anager portion

1. Use BUILD_IMAGE_TAG=v3 for manager image