### PR TITLE
NVSHAS-9537: Change BUILD_IMAGE_TAG=v3 for manager image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 STAGE_DIR = stage
 BASE_IMAGE_TAG = latest
-BUILD_IMAGE_TAG = latest
+BUILD_IMAGE_TAG = v3
 
 copy_mgr:
 	cp manager/licenses/* ${STAGE_DIR}/licenses/


### PR DESCRIPTION
Change existing builders base image to BCI with BUILD_IMAGE_TAG to v3