### PR TITLE
NVSHAS-9623: SSL private key parsing issue from using DerInputStream of sun.security with Scala 3 and JDK 17.

### DIFF
--- a/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
+++ b/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
@@ -1,34 +1,23 @@
 package com.neu.core
 
-import com.neu.core.CommonSettings.newCert
-import com.neu.core.CommonSettings.newKey
-import com.neu.core.CommonSettings.newMgrCert
-import com.neu.core.CommonSettings.newMgrKey
+import com.neu.core.CommonSettings.{ newCert, newKey, newMgrCert, newMgrKey }
 import com.typesafe.scalalogging.LazyLogging
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.*
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.asn1.{ ASN1InputStream, ASN1Integer, ASN1Sequence }
+import org.bouncycastle.cert.jcajce.{ JcaX509CertificateConverter, JcaX509v3CertificateBuilder }
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import org.bouncycastle.util.io.pem.PemObject
-import org.bouncycastle.util.io.pem.PemWriter
-import sun.security.util.DerInputStream
+import org.bouncycastle.util.io.pem.{ PemObject, PemWriter }
 
 import java.io.*
 import java.math.BigInteger
 import java.security.*
-import java.security.cert.Certificate
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
+import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
 import java.security.interfaces.RSAPrivateKey
 import java.security.spec.*
-import java.util.Base64
-import java.util.Date
-import javax.net.ssl.KeyManagerFactory
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLEngine
-import javax.net.ssl.TrustManagerFactory
+import java.util.{ Base64, Date }
+import javax.net.ssl.{ KeyManagerFactory, SSLContext, SSLEngine, TrustManagerFactory }
 import scala.jdk.CollectionConverters.*
 
 trait MySslConfiguration extends LazyLogging {
@@ -194,17 +183,20 @@ trait MySslConfiguration extends LazyLogging {
 
           val bytes = Base64.getDecoder.decode(encodedPrivateKey)
 
-          val derReader  = new DerInputStream(bytes)
-          val seq        = derReader.getSequence(0)
+          val asn1InputStream = new ASN1InputStream(bytes)
+          val seq             = ASN1Sequence.getInstance(asn1InputStream.readObject())
+          asn1InputStream.close()
+
           // skip version seq[0];
-          val modulus    = seq(1).getBigInteger
-          val publicExp  = seq(2).getBigInteger
-          val privateExp = seq(3).getBigInteger
-          val prime1     = seq(4).getBigInteger
-          val prime2     = seq(5).getBigInteger
-          val exp1       = seq(6).getBigInteger
-          val exp2       = seq(7).getBigInteger
-          val crtCoef    = seq(8).getBigInteger
+          val values     = seq.toArray
+          val modulus    = ASN1Integer.getInstance(values(1)).getPositiveValue
+          val publicExp  = ASN1Integer.getInstance(values(2)).getPositiveValue
+          val privateExp = ASN1Integer.getInstance(values(3)).getPositiveValue
+          val prime1     = ASN1Integer.getInstance(values(4)).getPositiveValue
+          val prime2     = ASN1Integer.getInstance(values(5)).getPositiveValue
+          val exp1       = ASN1Integer.getInstance(values(6)).getPositiveValue
+          val exp2       = ASN1Integer.getInstance(values(7)).getPositiveValue
+          val crtCoef    = ASN1Integer.getInstance(values(8)).getPositiveValue
 
           val keySpec    = new RSAPrivateCrtKeySpec(
             modulus,


### PR DESCRIPTION
Replaced the package we originally used sun.security.util.DerInputStream to org.bouncycastle.asn1.ASN1InputStream for parsing private key to solve the incompatibility issue in JDK 17.

Notes: 
1. The error occurs because Java 17 enforces stronger module encapsulation for internal sun.security.* packages.
2. Using internal APIs is discouraged as they may change or be removed in future Java releases, and existing potential security issues as well.