### PR TITLE
NVSHAS-9597 UI doesn't respond any error when controller returns 403 for POST(v1/group)

### DIFF
--- a/admin/webapp/websrc/app/core/interceptor/timeout.interceptor.ts
+++ b/admin/webapp/websrc/app/core/interceptor/timeout.interceptor.ts
@@ -53,7 +53,7 @@ export class TimeoutInterceptor implements HttpInterceptor {
               !req.url.endsWith(PathConstant.MULTI_CLUSTER_SUMMARY)) ||
             //For Rancher SSO from downstream cluster
             (status === GlobalConstant.STATUS_FORBIDDEN &&
-              error.error.Message.includes(
+              error.error?.Message?.includes(
                 GlobalConstant.RANCHER_AUTH_FAIL_MSG
               )) ||
             req.url === PathConstant.TOKEN_AUTH ||


### PR DESCRIPTION
Root cause: When a group name that already exists in the Policy->Groups page is added, the controller returns 403 "Object access denied" error. The UI's interceptor attempts to check the error content, which is null.

Solution: Add a null check before attempting to access the error content in the response to avoid potential errors when the content doesn't exist.