### PR TITLE
NVSHAS-9647 Default group export file name format changes

### DIFF
--- a/admin/webapp/websrc/app/common/utils/app.utils.ts
+++ b/admin/webapp/websrc/app/common/utils/app.utils.ts
@@ -453,6 +453,7 @@ export class UtilsService {
         .get('Content-Disposition')
         .split('=')[1]
         .trim()
+        .replace(/^"|"$/g, '')
         .split('.');
       return `${filename[0]}_${this.parseDatetimeStr(new Date())}.${
         filename[1]


### PR DESCRIPTION
Issue: 
When a file is downloaded using the Chrome browser, underscores are unexpectedly appended to the beginning and end of the filename. 

Cause:  
The underscores are being introduced because the filename is being parsed with leading and trailing double quotes. These quotes are interpreted as part of the filename, causing the undesired underscores.

Solution: 
To resolve this, we need to trim any leading and trailing double quotes from the filename (if they exist). 