### PR TITLE
NVSHAS-9670: Plain text response double quotes issue and java unnamed library issue in sbt run.

### DIFF
--- a/admin/src/main/scala/com/neu/service/DefaultJsonFormats.scala
+++ b/admin/src/main/scala/com/neu/service/DefaultJsonFormats.scala
@@ -28,6 +28,11 @@ import scala.reflect.ClassTag
  */
 trait DefaultJsonFormats extends DefaultJsonProtocol {
 
+  implicit val stringMarshaller: ToEntityMarshaller[String] =
+    Marshaller.withFixedContentType(ContentTypes.`text/plain(UTF-8)`) { str =>
+      HttpEntity(ContentTypes.`text/plain(UTF-8)`, str)
+    }
+
   implicit val stringUnmarshaller: FromEntityUnmarshaller[String] = Unmarshaller.stringUnmarshaller
 
   // JSON marshalling and unmarshalling support

--- a/admin/webapp/websrc/app/routes/components/file-access-rules/partial/predefined-file-access-rules-modal/operation-cell/operation-cell/operation-cell.component.ts
+++ b/admin/webapp/websrc/app/routes/components/file-access-rules/partial/predefined-file-access-rules-modal/operation-cell/operation-cell/operation-cell.component.ts
@@ -63,8 +63,7 @@ export class OperationCellComponent implements ICellRendererAngularComp {
           updateGridData(
             this.params.context.componentParent.predefinedFileAccessRules,
             [predefinedRule],
-            this.params.context.componentParent
-              .gridApi!,
+            this.params.context.componentParent.gridApi!,
             'filter',
             'delete'
           );

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val buildSettings = Seq(
     "-unchecked",            // warn about unchecked type parameters
     "-feature",              // warn about misused language features
     "-language:higherKinds", // allow higher kinded types without `import scala.language.higherKinds`
-    "-source:future",         // enable future language features
+    "-source:future",        // enable future language features
     "-Wunused:all"           // add required compiler option for RemoveUnused[1]
   ),
   Compile / console / scalacOptions --= Seq("-Ywarn-unused", "-Ywarn-unused-import")
@@ -56,6 +56,24 @@ lazy val commonDependencies = Seq(
   "org.apache.commons" % "commons-csv"        % "1.10.0"
 )
 
+lazy val commonSettings = Seq(
+  javaOptions ++= Seq(
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED"
+  ),
+  Test / javaOptions ++= Seq(
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED"
+  ),
+  run / javaOptions ++= Seq(
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED"
+  )
+)
+
 lazy val buil1dSettings = Defaults.coreDefaultSettings ++ Seq(
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-target:jvm-1.7"),
   libraryDependencies                        := Seq(scalaTest),
@@ -80,6 +98,7 @@ lazy val common = (project in file("common"))
   .settings(
     name        := "common",
     buildSettings,
+    commonSettings,
     promptTheme := ScalapenosTheme,
     libraryDependencies ++= commonDependencies
   )
@@ -89,6 +108,7 @@ lazy val admin = (project in file("admin"))
   .settings(
     name        := "admin",
     buildSettings,
+    commonSettings,
     promptTheme := ScalapenosTheme,
     libraryDependencies += pekkoHttp,
     libraryDependencies += pekkoJson,


### PR DESCRIPTION
1. Plain text response double quotes issue.

Added custom marshaller to avoid double quotes.

![image](https://github.com/user-attachments/assets/b4421b38-425e-4b22-a395-4a0aa02fa83b)

2. Java unnamed library issue in sbt run.

Added add-opens Java API usage into build.sbt.

```
lazy val commonSettings = Seq(
  javaOptions ++= Seq(
    "--add-opens=java.base/java.lang=ALL-UNNAMED",
    "--add-opens=java.base/java.util=ALL-UNNAMED",
    "--add-opens=java.base/java.io=ALL-UNNAMED"
  ),
  Test / javaOptions ++= Seq(
    "--add-opens=java.base/java.lang=ALL-UNNAMED",
    "--add-opens=java.base/java.util=ALL-UNNAMED",
    "--add-opens=java.base/java.io=ALL-UNNAMED"
  ),
  run / javaOptions ++= Seq(
    "--add-opens=java.base/java.lang=ALL-UNNAMED",
    "--add-opens=java.base/java.util=ALL-UNNAMED",
    "--add-opens=java.base/java.io=ALL-UNNAMED"
  )
)
```

![image](https://github.com/user-attachments/assets/e95d57db-eb73-47c3-8a69-1d2041c5a6ea)

Note: Note: Java API usage is a kind of workaround that should be revised if there are any better solutions in further.
