### PR TITLE
NVSHAS-9590 To choose which vulnerability score for all assets.

### DIFF
--- a/admin/webapp/websrc/app/routes/components/vulnerabilities-grid/vulnerabilities-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/vulnerabilities-grid/vulnerabilities-grid.component.ts
@@ -25,6 +25,7 @@ import {
   FEED_RATING_SORT_ORDER,
   capitalizeWord,
 } from '@common/utils/common.utils';
+import { VulnerabilityItemsTableScoreCellComponent } from '@routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-score-cell/vulnerability-items-table-score-cell.component';
 
 @Component({
   selector: 'app-vulnerabilities-grid',
@@ -63,9 +64,32 @@ export class VulnerabilitiesGridComponent implements OnInit, OnChanges {
     },
     {
       field: 'score',
-      valueFormatter: this.scoreFormatter,
-      headerValueGetter: () => this.translate.instant('scan.gridHeader.SCORE'),
-      width: 160,
+      hide: true,
+      sortable: true,
+      resizable: true,
+      cellRenderer: 'scoreCellRenderer',
+      cellRendererParams: {
+        type: 'V2',
+      },
+      headerValueGetter: () =>
+        this.translate.instant('scan.gridHeader.SCORE_V2'),
+      width: 140,
+      maxWidth: 140,
+      minWidth: 140,
+    },
+    {
+      field: 'score_v3',
+      sortable: true,
+      resizable: true,
+      cellRenderer: 'scoreCellRenderer',
+      cellRendererParams: {
+        type: 'V3',
+      },
+      headerValueGetter: () =>
+        this.translate.instant('scan.gridHeader.SCORE_V3'),
+      width: 140,
+      maxWidth: 140,
+      minWidth: 140,
     },
     {
       field: 'feed_rating',
@@ -133,6 +157,7 @@ export class VulnerabilitiesGridComponent implements OnInit, OnChanges {
       onSelectionChanged: event => this.onSelectionChanged(event),
       components: {
         severityCellRenderer: VulnerabilitiesGridSeverityCellComponent,
+        scoreCellRenderer: VulnerabilityItemsTableScoreCellComponent,
       },
     };
   }
@@ -187,12 +212,6 @@ export class VulnerabilitiesGridComponent implements OnInit, OnChanges {
 
   onResize(): void {
     this.gridApi.sizeColumnsToFit();
-  }
-
-  scoreFormatter(params: ValueFormatterParams): string {
-    const v2 = params.data.score;
-    const v3 = params.data.score_v3;
-    return `${v2}/${v3}`;
   }
 
   dateFormatter(params: ValueFormatterParams): string {

--- a/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.html
+++ b/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.html
@@ -22,6 +22,20 @@
     <ng-container *ngSwitchCase="'vulnerabilities'">
       <div class="filter" [class]="'filter-icon-' + visibleIcons">
         <div class="d-flex">
+          <button
+            [matMenuTriggerFor]="menu"
+            class="mx-2 d-flex align-items-center justify-content-center"
+            mat-button>
+            {{ activeScore }} <i class="eos-icons">arrow_drop_down</i>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button (click)="changeScoreView('V2')" mat-menu-item>
+              {{ 'scan.gridHeader.SCORE_V2' | translate }}
+            </button>
+            <button (click)="changeScoreView('V3')" mat-menu-item>
+              {{ 'scan.gridHeader.SCORE_V3' | translate }}
+            </button>
+          </mat-menu>
           <ng-container *ngIf="isVulsAuthorized">
             <button
               *ngIf="

--- a/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.scss
+++ b/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.scss
@@ -1,6 +1,6 @@
 .filter {
   position: relative;
-  left: calc(100% - 180px);
+  left: calc(100% - 320px);
   top: -4px;
   z-index: 10000;
   display: flex;
@@ -8,15 +8,15 @@
 }
 
 .filter-icon-1 {
-  left: calc(100% - 236px) !important;
+  left: calc(100% - 376px) !important;
 }
 
 .filter-icon-2 {
-  left: calc(100% - 292px) !important;
+  left: calc(100% - 432px) !important;
 }
 
 .filter-icon-3 {
-  left: calc(100% - 348px) !important;
+  left: calc(100% - 488px) !important;
 }
 
 .detail-tabs {

--- a/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.ts
+++ b/admin/webapp/websrc/app/routes/containers/container-details/container-details.component.ts
@@ -80,6 +80,7 @@ export class ContainerDetailsComponent implements OnInit, OnDestroy {
   @ViewChild('acceptedTooltip') acceptedTooltip!: MatTooltip;
   isVulsAuthorized!: boolean;
   isWriteVulsAuthorized!: boolean;
+  selectedVulScore: String = 'V3';
   get processHistoryMsg() {
     return !this.showProcessHistory
       ? this.tr.instant('containers.process.SHOW_EXITED')
@@ -108,6 +109,11 @@ export class ContainerDetailsComponent implements OnInit, OnDestroy {
     const toggleVul = this.isVulsAuthorized;
     const csv = !this.vulEmpty;
     return +acceptVul + +toggleVul + +csv;
+  }
+  get activeScore() {
+    return this.selectedVulScore === 'V2'
+      ? this.tr.instant('scan.gridHeader.SCORE_V2')
+      : this.tr.instant('scan.gridHeader.SCORE_V3');
   }
 
   constructor(
@@ -316,5 +322,17 @@ export class ContainerDetailsComponent implements OnInit, OnDestroy {
     }
     if (![1, 2].includes(this.activeTabIndex))
       this.versionInfoService.setVersionInfo(null, '');
+  }
+  changeScoreView(val: string) {
+    this.selectedVulScore = val;
+    if (val === 'V2') {
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], true);
+    } else {
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], true);
+    }
+    this.vulGrid.gridApi.sizeColumnsToFit();
+    this.cd.markForCheck();
   }
 }

--- a/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.html
+++ b/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.html
@@ -26,6 +26,20 @@
         [class.filter-view]="isVulsAuthorized && vulEmpty">
         <div class="mr-3 filter-actions">
           <button
+            [matMenuTriggerFor]="menu"
+            class="mx-2 d-flex align-items-center justify-content-center"
+            mat-button>
+            {{ activeScore }} <i class="eos-icons">arrow_drop_down</i>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button (click)="changeScoreView('V2')" mat-menu-item>
+              {{ 'scan.gridHeader.SCORE_V2' | translate }}
+            </button>
+            <button (click)="changeScoreView('V3')" mat-menu-item>
+              {{ 'scan.gridHeader.SCORE_V3' | translate }}
+            </button>
+          </mat-menu>
+          <button
             mat-button
             aria-label="Export vulnerabilities CSV"
             type="button"

--- a/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.scss
+++ b/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.scss
@@ -1,6 +1,6 @@
 .filter {
   position: relative;
-  left: calc(100% - 196px);
+  left: calc(100% - 336px);
   top: -4px;
   z-index: 10000;
   display: flex;
@@ -12,19 +12,19 @@
 }
 
 .filter-csv {
-  left: calc(100% - 286.5px) !important;
+  left: calc(100% - 396.5px) !important;
 }
 
 .filter-view {
-  left: calc(100% - 288.5px) !important;
+  left: calc(100% - 428.5px) !important;
 }
 
 .filter-view-csv {
-  left: calc(100% - 379px) !important;
+  left: calc(100% - 489px) !important;
 }
 
 .filter-container {
-  left: calc(100% - 236px) !important;
+  left: calc(100% - 346px) !important;
 }
 
 .node-detail-tab-group {

--- a/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.ts
+++ b/admin/webapp/websrc/app/routes/nodes/node-details/node-details.component.ts
@@ -76,6 +76,7 @@ export class NodeDetailsComponent implements OnInit {
   showSysContainers: boolean = false;
   isVulsAuthorized!: boolean;
   isWriteVulsAuthorized!: boolean;
+  selectedVulScore: String = 'V3';
   get sysContainersMsg() {
     return !this.showSysContainers
       ? this.tr.instant('nodes.containers.SHOW_SYS_NODE')
@@ -88,6 +89,11 @@ export class NodeDetailsComponent implements OnInit {
   }
   get activeTab(): string {
     return nodeDetailsTabs[this.activeTabIndex];
+  }
+  get activeScore() {
+    return this.selectedVulScore === 'V2'
+      ? this.tr.instant('scan.gridHeader.SCORE_V2')
+      : this.tr.instant('scan.gridHeader.SCORE_V3');
   }
 
   constructor(
@@ -247,5 +253,18 @@ export class NodeDetailsComponent implements OnInit {
     }
     if (![1, 2].includes(this.activeTabIndex))
       this.versionInfoService.setVersionInfo(null, '');
+  }
+
+  changeScoreView(val: string) {
+    this.selectedVulScore = val;
+    if (val === 'V2') {
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], true);
+    } else {
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], true);
+    }
+    this.vulGrid.gridApi.sizeColumnsToFit();
+    this.cd.markForCheck();
   }
 }

--- a/admin/webapp/websrc/app/routes/platforms/platform-details/platform-details.component.html
+++ b/admin/webapp/websrc/app/routes/platforms/platform-details/platform-details.component.html
@@ -16,6 +16,20 @@
       </em>
     </div>
     <div class="d-flex align-items-baseline justify-content-end">
+      <button
+        [matMenuTriggerFor]="menu"
+        class="mx-2 d-flex align-items-center justify-content-center"
+        mat-button>
+        {{ activeScore }} <i class="eos-icons">arrow_drop_down</i>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button (click)="changeScoreView('V2')" mat-menu-item>
+          {{ 'scan.gridHeader.SCORE_V2' | translate }}
+        </button>
+        <button (click)="changeScoreView('V3')" mat-menu-item>
+          {{ 'scan.gridHeader.SCORE_V3' | translate }}
+        </button>
+      </mat-menu>
       <div class="mr-3 d-flex">
         <button
           mat-button

--- a/admin/webapp/websrc/app/routes/platforms/platform-details/platform-details.component.ts
+++ b/admin/webapp/websrc/app/routes/platforms/platform-details/platform-details.component.ts
@@ -53,6 +53,7 @@ export class PlatformDetailsComponent implements OnInit {
   showAcceptedVuls: boolean = false;
   isVulsAuthorized!: boolean;
   isWriteVulsAuthorized!: boolean;
+  selectedVulScore: String = 'V3';
 
   constructor(
     public versionInfoService: VersionInfoService,
@@ -155,5 +156,24 @@ export class PlatformDetailsComponent implements OnInit {
     if (vulnerabilities4Csv.length) {
       this.utils.exportCVE(this.platform.platform, vulnerabilities4Csv);
     }
+  }
+
+  get activeScore() {
+    return this.selectedVulScore === 'V2'
+      ? this.tr.instant('scan.gridHeader.SCORE_V2')
+      : this.tr.instant('scan.gridHeader.SCORE_V3');
+  }
+
+  changeScoreView(val: string) {
+    this.selectedVulScore = val;
+    if (val === 'V2') {
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], true);
+    } else {
+      this.vulGrid.gridApi?.setColumnsVisible(['score'], false);
+      this.vulGrid.gridApi?.setColumnsVisible(['score_v3'], true);
+    }
+    this.vulGrid.gridApi.sizeColumnsToFit();
+    this.cd.markForCheck();
   }
 }

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-vulnerabilities/registry-vulnerabilities.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-vulnerabilities/registry-vulnerabilities.component.html
@@ -16,6 +16,20 @@
     >
   </div>
   <div class="d-flex flex-row justify-content-center align-items-center">
+    <button
+      [matMenuTriggerFor]="menu"
+      class="mx-2 d-flex align-items-center justify-content-center"
+      mat-button>
+      {{ activeScore }} <i class="eos-icons">arrow_drop_down</i>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button (click)="changeScoreView('V2')" mat-menu-item>
+        {{ 'scan.gridHeader.SCORE_V2' | translate }}
+      </button>
+      <button (click)="changeScoreView('V3')" mat-menu-item>
+        {{ 'scan.gridHeader.SCORE_V3' | translate }}
+      </button>
+    </mat-menu>
     <button [matMenuTriggerFor]="menu" class="p-2" mat-button>
       {{ 'network.SETTING' | translate }}
       <i class="eos-icons mb-1">arrow_drop_down</i>

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.html
@@ -11,9 +11,10 @@
   <div class="d-flex justify-content-end align-items-center">
     <button
       [matMenuTriggerFor]="menu"
-      class="mx-2 d-flex align-items-center justify-content-center<i class='eos-icons'>done</i>a"
+      class="mx-2 d-flex align-items-center justify-content-center"
       mat-button>
-      {{ activeScore }} <i class="eos-icons">arrow_drop_down</i>
+      {{ activeScore }}
+      <i class="eos-icons">arrow_drop_down</i>
     </button>
     <mat-menu #menu="matMenu">
       <button (click)="changeScoreView('V2')" mat-menu-item>


### PR DESCRIPTION
This PR introduces a feature that allows users to select a specific vulnerability score to be used for all assets (Platform, Nodes, Container, Registry).

Changes:

- A dropdown (or equivalent) has been added to the UI for score selection

![Select_Vulnerability_Score_for_All_Assets](https://github.com/user-attachments/assets/884deb49-d4f8-403c-a49c-57044665f7f4)
