### PR TITLE
NVSHAS-9704/NVSHAS-9721: error messages are not showing up

### DIFF
--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -48,10 +48,7 @@ trait Api extends Directives with CoreActors with Core {
         complete(
           HttpResponse(
             status = e.statusCode,
-            entity = HttpEntity(
-              e.response.entity.contentType.asInstanceOf[ContentType.NonBinary],
-              e.reason
-            )
+            entity = e.response.entity
           )
         )
       case e: Exception             =>

--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -26,7 +26,7 @@ import com.neu.service.policy.PolicyService
 import com.neu.service.risk.RiskService
 import com.neu.service.sigstore.SigstoreService
 import com.neu.service.workload.WorkloadService
-import org.apache.pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpResponse }
+import org.apache.pekko.http.scaladsl.model.{ ContentType, ContentTypes, HttpEntity, HttpResponse }
 import org.apache.pekko.http.scaladsl.server.{ Directives, ExceptionHandler, Route }
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -48,7 +48,10 @@ trait Api extends Directives with CoreActors with Core {
         complete(
           HttpResponse(
             status = e.statusCode,
-            entity = HttpEntity(ContentTypes.`application/json`, e.reason)
+            entity = HttpEntity(
+              e.response.entity.contentType.asInstanceOf[ContentType.NonBinary],
+              e.reason
+            )
           )
         )
       case e: Exception             =>

--- a/admin/src/main/scala/com/neu/core/ClientSslConfig.scala
+++ b/admin/src/main/scala/com/neu/core/ClientSslConfig.scala
@@ -7,6 +7,7 @@ import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.HttpsConnectionContext
 import org.apache.pekko.http.scaladsl.model.*
 import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
@@ -83,7 +84,7 @@ trait ClientSslConfig extends LazyLogging {
               Future.successful(response)
             case status                                               =>
               logger.info(
-                s"Received Response - Failure\nStatusCode: ${status.intValue()} Reason: ${status.reason()}\n$response"
+                s"Received Response - Failure\nStatusCode: ${status.intValue()} Reason: ${status.reason()}\n Exception: ${Unmarshal(response.entity).to[String]}"
               )
               Future.failed(HttpResponseException(status.intValue(), status.reason(), response))
           }

--- a/admin/webapp/websrc/app/common/api/config-http.service.ts
+++ b/admin/webapp/websrc/app/common/api/config-http.service.ts
@@ -139,10 +139,16 @@ export class ConfigHttpService {
         catchError(error => {
           const textDecoder = new TextDecoder();
           let errorRes = textDecoder.decode(error.error);
-          error.error =
-            error.headers.get('Content-type') === 'application/json'
-              ? JSON.parse(errorRes).message
-              : errorRes;
+
+          try {
+            error.error =
+              error.headers.get('Content-type') === 'application/json'
+                ? JSON.parse(errorRes).message
+                : errorRes;
+          } catch {
+            error.error = errorRes;
+          }
+
           return throwError(error);
         })
       );

--- a/admin/webapp/websrc/app/routes/settings/configuration/csp-support-form/csp-support-form.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/csp-support-form/csp-support-form.component.ts
@@ -5,9 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { UtilsService } from '@common/utils/app.utils';
 import { finalize } from 'rxjs/operators';
 import { saveAs } from 'file-saver';
-import { GlobalConstant } from '@common/constants/global.constant';
 import { NotificationService } from '@services/notification.service';
-import { ErrorResponse } from '@common/types';
 import * as moment from 'moment';
 
 @Component({


### PR DESCRIPTION
Fix to correctly show up error message from return error response entity for custom exception instead of error reason.

Error showing correctly in csp-support panel of configuration.
<img width="1512" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/6e99c160-9e84-44ff-ae56-97904bdd8bc5" />

Error showing correctly in registry page.
<img width="1512" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/d9616be3-336f-4677-b377-56bb383f34f8" />

