### PR TITLE
fix: fix npm package severity issue

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,7 +18,9 @@ COPY build.sbt .scalafix.conf .scalafmt.conf /src/
 WORKDIR /src
 
 RUN zypper refresh && \
-    zypper install -y ca-certificates wget curl zip git awk nodejs20 npm20
+    zypper install -y wget curl zip git awk nodejs20 npm20 && \
+    npm install -g npm@10.9.2 && \
+    hash -r
 
 ARG VERSION
 
@@ -92,7 +94,8 @@ ARG COMMIT
 WORKDIR /
 COPY --from=base /chroot/ /
 COPY --from=base /usr/sbin/useradd /usr/sbin
-COPY --from=builder /usr/lib64/ /usr/lib64/
+COPY --from=builder /usr/lib64/jvm /usr/lib64/jvm
+COPY --from=builder /usr/lib64/lib*.so* /usr/lib64/
 COPY --from=builder /src/stage /
 
 ENV JAVA_HOME=/usr/lib64/jvm/java-17-openjdk-17 \

--- a/package/build_manager.sh
+++ b/package/build_manager.sh
@@ -12,7 +12,6 @@ if [[ $# > 0 ]]; then
         -d)
         mkdir -p /root/.ivy2
         ln -s /prebuild/manager/cache /root/.ivy2/cache
-        # ln -s /prebuild/manager/node_modules node_modules
         ;;
         *)
         ;;
@@ -43,7 +42,6 @@ else
     echo ================================
     exit 1
 fi
-# npm run unittest
 popd
 env JAVA_OPTS="-Xms2g -Xmx3g" sbt admin/assembly
 zip -d admin/target/scala-3.3.4/admin-assembly-1.0.jar rest-management-private-classpath\*


### PR DESCRIPTION
upgrade npm from v10.8.2 to v10.9.2

exclude node_moduels of usr/lib64 of package/Dockerfile build image

clean up unused scripts of package/build_manager.sh