### PR TITLE
NVSHAS-9750: WebUI is not working with standalone manager run as docker container. (5.4.2 Cherry-pick)

### DIFF
--- a/Dockerfile.manager
+++ b/Dockerfile.manager
@@ -3,7 +3,7 @@ ARG BASE_IMAGE_TAG
 FROM neuvector/${BASE_PREFIX}manager_base:${BASE_IMAGE_TAG}
 
 COPY stage /
-COPY stage/usr/lib/jvm/java-17-openjdk/lib/security/java.security /usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security
+COPY stage/usr/lib/jvm/java-17-openjdk/lib/security/java.security /usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips
 
 ARG NV_TAG
 LABEL name="manager" \
@@ -19,4 +19,4 @@ RUN echo "$user:x:1000:1000::/nonexistent:/bin/bash" >> /etc/passwd && \
     echo "$user:x:1000:" >> /etc/group
 USER $user
 
-ENTRYPOINT ["java", "-Xms256m", "-Xmx2048m", "-Djdk.tls.rejectClientInitiatedRenegotiation=true", "-Dpekko.http.parsing.max-header-value-length=32k", "--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "-jar", "/usr/local/bin/admin-assembly-1.0.jar"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ copy_mgr:
 	cp manager/scripts/* ${STAGE_DIR}/usr/local/bin/
 	cp manager/java.security ${STAGE_DIR}/usr/lib/jvm/java-17-openjdk/lib/security/java.security
 	cp manager/admin/target/scala-3.3.4/admin-assembly-1.0.jar ${STAGE_DIR}/usr/local/bin/
+	cp manager/package/entrypoint.sh ${STAGE_DIR}/entrypoint.sh
 
 stage_init:
 	rm -rf ${STAGE_DIR}; mkdir -p ${STAGE_DIR}

--- a/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
+++ b/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
@@ -263,8 +263,15 @@ trait MySslConfiguration extends LazyLogging {
 
   def configureSSLEngine(engine: SSLEngine): SSLEngine = {
     engine.setUseClientMode(false)
-    engine.setEnabledCipherSuites(Array("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"))
-    engine.setEnabledProtocols(Array("TLSv1.2"))
+    engine.setEnabledCipherSuites(
+      Array(
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384"
+      )
+    )
+    engine.setEnabledProtocols(Array("TLSv1.2", "TLSv1.3"))
     engine
   }
 }

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -96,6 +96,7 @@ COPY --from=base /chroot/ /
 COPY --from=base /usr/sbin/useradd /usr/sbin
 COPY --from=builder /usr/lib64/jvm /usr/lib64/jvm
 COPY --from=builder /usr/lib64/lib*.so* /usr/lib64/
+COPY --from=builder /src/package/entrypoint.sh /entrypoint.sh
 COPY --from=builder /src/stage /
 
 ENV JAVA_HOME=/usr/lib64/jvm/java-17-openjdk-17 \
@@ -122,4 +123,4 @@ RUN echo "$user:x:1000:1000::/nonexistent:/bin/bash" >> /etc/passwd && \
     echo "$user:x:1000:" >> /etc/group
 USER $user
 
-ENTRYPOINT ["java", "-Xms256m", "-Xmx2048m", "-Djdk.tls.rejectClientInitiatedRenegotiation=true", "-Dpekko.http.parsing.max-header-value-length=32k", "--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "-jar", "/usr/local/bin/admin-assembly-1.0.jar"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/package/build_manager.sh
+++ b/package/build_manager.sh
@@ -47,12 +47,11 @@ env JAVA_OPTS="-Xms2g -Xmx3g" sbt admin/assembly
 zip -d admin/target/scala-3.3.4/admin-assembly-1.0.jar rest-management-private-classpath\*
 rm -rf admin/webapp/root/.sass-cache
 
-mkdir -p ${STAGE_DIR}/licenses/ ${STAGE_DIR}/usr/local/bin/ ${STAGE_DIR}/usr/lib/jvm/java-17-openjdk/lib/security ${STAGE_DIR}/usr/lib64/jvm/java-17-openjdk-17/conf/security/
+mkdir -p ${STAGE_DIR}/licenses/ ${STAGE_DIR}/usr/local/bin/ ${STAGE_DIR}/usr/lib64/jvm/java-17-openjdk-17/conf/security/
 cp licenses/* ${STAGE_DIR}/licenses/
 cp cli/cli ${STAGE_DIR}/usr/local/bin/
 cp cli/cli.py ${STAGE_DIR}/usr/local/bin/
 cp -r cli/prog ${STAGE_DIR}/usr/local/bin/
 cp scripts/* ${STAGE_DIR}/usr/local/bin/
-cp java.security ${STAGE_DIR}/usr/lib/jvm/java-17-openjdk/lib/security/
-cp java.security ${STAGE_DIR}/usr/lib64/jvm/java-17-openjdk-17/conf/security/
+cp java.security ${STAGE_DIR}/usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips
 cp admin/target/scala-3.3.4/admin-assembly-1.0.jar ${STAGE_DIR}/usr/local/bin/

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ -f /proc/sys/crypto/fips_enabled ] && [ "$(cat /proc/sys/crypto/fips_enabled)" -eq 1 ]; then
+    echo "FIPS mode detected (via /proc/sys/crypto/fips_enabled)."
+    JAVA_SECURITY_FILE="/usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips"
+else
+    echo "FIPS mode not detected. Using default security configuration."
+    JAVA_SECURITY_FILE="/usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.default"
+fi
+
+exec java \
+  -Xms256m \
+  -Xmx2048m \
+  -Djdk.tls.rejectClientInitiatedRenegotiation=true \
+  -Dpekko.http.parsing.max-header-value-length=32k \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  -Djava.security.properties=="$JAVA_SECURITY_FILE" \
+  -jar /usr/local/bin/admin-assembly-1.0.jar


### PR DESCRIPTION


separated java.security file usage from fips and non-fips at the execution command