### PR TITLE
NVSHAS-9780: NeuVector single sign on not working with Rancher NavLink

### DIFF
--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -13,10 +13,12 @@ import com.neu.api.workload.WorkloadApi
 import com.neu.client.RestClient.handleError
 import com.neu.core.{ Core, CoreActors, HttpResponseException }
 import com.neu.service.*
-import com.neu.service.authentication.AuthProvider
-import com.neu.service.authentication.AuthService
-import com.neu.service.authentication.AuthServiceFactory
-import com.neu.service.authentication.ExtraAuthService
+import com.neu.service.authentication.{
+  AuthProvider,
+  AuthService,
+  AuthServiceFactory,
+  ExtraAuthService
+}
 import com.neu.service.cluster.ClusterService
 import com.neu.service.dashboard.DashboardService
 import com.neu.service.device.DeviceService
@@ -26,7 +28,7 @@ import com.neu.service.policy.PolicyService
 import com.neu.service.risk.RiskService
 import com.neu.service.sigstore.SigstoreService
 import com.neu.service.workload.WorkloadService
-import org.apache.pekko.http.scaladsl.model.{ ContentType, ContentTypes, HttpEntity, HttpResponse }
+import org.apache.pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpResponse }
 import org.apache.pekko.http.scaladsl.server.{ Directives, ExceptionHandler, Route }
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -13,7 +13,6 @@ exec java \
   -Xms256m \
   -Xmx2048m \
   -Djdk.tls.rejectClientInitiatedRenegotiation=true \
-  -Dpekko.http.parsing.max-header-value-length=32k \
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens=java.base/java.util=ALL-UNNAMED \


### PR DESCRIPTION
Before fix: 
```
 curl 'https://localhost:8443/host' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9,zh-TW;q=0.8,zh;q=0.7' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: R_PCS=light; R_REDIRECTED=true; R_LOCALE=en-us; CSRF=*****' \
  -H 'Pragma: no-cache' \
  -H 'Referer: https://localhost:8443/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'token: *****' \
  -H "Large-Header: $(printf '%s' $(head -c 32768 < /dev/zero | tr '\0' 'x'))" \
  --insecure

HTTP header value exceeds the configured limit of 8192 characters
```

After fix: 
```
curl 'https://localhost:8443/host' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9,zh-TW;q=0.8,zh;q=0.7' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: R_PCS=light; R_REDIRECTED=true; R_LOCALE=en-us; CSRF=*****' \
  -H 'Pragma: no-cache' \
  -H 'Referer: https://localhost:8443/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'token: *****' \
  -H "Large-Header: $(printf '%s' $(head -c 32768 < /dev/zero | tr '\0' 'x'))" \
  --insecure

{"code":3,"error":"Authentication failed","message":"Authentication failed"}
```