### PR TITLE
NVSHAS-9325: update CLI shell to bash

### DIFF
--- a/cli/cli
+++ b/cli/cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ -f /.venv/bin/activate ]; then
     source /.venv/bin/activate
 fi


### PR DESCRIPTION
CLI: update the default shell from "sh" to "bash"