### PR TITLE
NVSHAS-9801: FIPS mode + manager.env.ssl=false causes Manager to error out.

### DIFF
--- a/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
+++ b/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
@@ -18,8 +18,26 @@ import java.security.cert.{ Certificate, CertificateFactory, X509Certificate }
 import java.security.interfaces.RSAPrivateKey
 import java.security.spec.*
 import java.util.{ Base64, Date }
-import javax.net.ssl.{ KeyManagerFactory, SSLContext, SSLEngine, TrustManagerFactory }
+import javax.net.ssl.{
+  KeyManager,
+  KeyManagerFactory,
+  SSLContext,
+  SSLEngine,
+  TrustManager,
+  TrustManagerFactory
+}
 import scala.jdk.CollectionConverters.*
+
+object NoOperationSSLContext {
+  def init(): Unit = {
+    Security.addProvider(new BouncyCastleProvider())
+    Security.addProvider(new BouncyCastleJsseProvider())
+
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.init(Array[KeyManager](), Array[TrustManager](), null)
+    SSLContext.setDefault(sslContext)
+  }
+}
 
 trait MySslConfiguration extends LazyLogging {
 


### PR DESCRIPTION
Ref: [https://github.com/neuvector/neuvector/issues/1757](url)

The issue is from the default SSL context check by Pekko, fixed by setting the default SSL context of non-SSL operations.

Revised Log:
```
manager  | FIPS mode detected (via /proc/sys/crypto/fips_enabled).
manager  | 2025-01-29 14:31:15,593|INFO |MANAGER|apache.pekko.event.slf4j.Slf4jLogger(applyOrElse:117): Slf4jLogger started
manager  | Jan 29, 2025 2:31:17 PM org.bouncycastle.jsse.provider.PropertyUtils getStringSecurityProperty
manager  | INFO: Found string security property [jdk.tls.disabledAlgorithms]: DH keySize < 2048, TLSv1.1, TLSv1, SSLv3, SSLv2, DHE_DSS, RSA_EXPORT, DHE_DSS_EXPORT, DHE_RSA_EXPORT, DH_DSS_EXPORT, DH_RSA_EXPORT, DH_anon, ECDH_anon, DH_RSA, DH_DSS, ECDH, 3DES_EDE_CBC, DES_CBC, RC4_40, RC4_128, DES40_CBC, RC2, HmacMD5
manager  | Jan 29, 2025 2:31:17 PM org.bouncycastle.jsse.provider.PropertyUtils getStringSecurityProperty
manager  | INFO: Found string security property [jdk.certpath.disabledAlgorithms]: MD2, SHA1, MD5, DSA, RSA keySize < 2048
manager  | 2025-01-29 14:31:18,267|INFO |MANAGER|com.neu.web.Rest$($init$:66): Starting server in HTTP mode (MANAGER_SSL=off).
manager  | 2025-01-29 14:31:18,623|INFO |MANAGER|com.neu.web.Rest$($init$$$anonfun$2:88): Server is listening on /[0:0:0:0:0:0:0:0]:8443
```