### PR TITLE
NVSHAS-9811: Unable to access GUI when using custom certificate with root CA and intermediate CA on the secret.

### DIFF
--- a/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
+++ b/admin/src/main/scala/com/neu/core/MySslConfiguration.scala
@@ -160,7 +160,7 @@ trait MySslConfiguration extends LazyLogging {
     val cf: CertificateFactory = CertificateFactory.getInstance("X.509")
     val trustManagerFactory    = TrustManagerFactory.getInstance("PKIX")
     val keyManagerFactory      = KeyManagerFactory.getInstance("PKIX")
-    val ks: KeyStore           = KeyStore.getInstance("PKCS12")
+    val ks: KeyStore           = KeyStore.getInstance("JKS")
     val keyFactory: KeyFactory = KeyFactory.getInstance("RSA")
 
     var fisCert: FileInputStream     = null


### PR DESCRIPTION
I changed the keystore from a more constrained one to the original one.