### PR TITLE
NV9325: follow-up, update default shell to bash

### DIFF
--- a/scripts/support
+++ b/scripts/support
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ -f /.venv/bin/activate ]; then
     source /.venv/bin/activate
 fi


### PR DESCRIPTION
Update it with the default shell of the BCI: bash.