### PR TITLE
NVSHAS-9845 UI: Github Registry type should limit filter to scan whole repos

### DIFF
--- a/admin/webapp/websrc/app/common/neuvector-formly/formlyValidators.ts
+++ b/admin/webapp/websrc/app/common/neuvector-formly/formlyValidators.ts
@@ -98,7 +98,7 @@ export function repoFilterValidator(
 ): ValidationErrors | null {
   const value = control.value;
   const pattern = new RegExp(
-    /^(([a-z0-9](?:[._-]?[a-z0-9]+)*)\/)+([a-z0-9_.*:-]*)$/
+    /^(([a-z0-9](?:[._-]?[a-z0-9]+)*)\/)+([a-z0-9_.*:-]+)$/
   );
   if (!value) {
     return null;


### PR DESCRIPTION
Modify the Github Registry Filter Validation Regex to `^(([a-z0-9](?:[._-]?[a-z0-9]+)*)\/)+([a-z0-9_.*:-]+)$` (adjust the quantifier from * to + ) , which prevents cases like "myrepo/" a trailing slash without anything after