### PR TITLE
NVSHAS-9873: UI Advanced Filter search issue in NeuVector 5.4.2

### DIFF
--- a/admin/webapp/websrc/app/common/types/common/common.ts
+++ b/admin/webapp/websrc/app/common/types/common/common.ts
@@ -21,7 +21,11 @@ export type DataOps = 'add' | 'edit' | 'delete';
 
 export type VulQueryPublishedTimeOption = 'all' | 'before' | 'after';
 
-export type VulQueryPackageTypeOption = 'all' | 'withfix' | 'withoutfix';
+export type VulQueryPackageTypeOption =
+  | 'all'
+  | 'withFix'
+  | 'withoutFix'
+  | 'withFixAll';
 
 export type VulQuerySeverityTypeOption = 'all' | 'high' | 'medium' | 'low';
 

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
@@ -73,7 +73,7 @@
         <mat-datepicker #picker></mat-datepicker>
       </mat-form-field>
     </section>
-    <section class="row mx-0">
+    <section class="row mx-0 mt-2">
       <span class="d-block col-2">{{
         'cis.report.gridHeader.SCORED' | translate
       }}</span>
@@ -81,16 +81,18 @@
         aria-label="Scored"
         class="col row"
         formControlName="packageType">
-        <mat-radio-button class="col" value="all">{{
+        <mat-radio-button class="col-2" value="all">{{
           'setting.ALL' | translate
         }}</mat-radio-button>
-        <mat-radio-button class="col" value="withFix">{{
+        <mat-radio-button class="col-3" value="withFix">{{
           'scan.WITH_FIX' | translate
         }}</mat-radio-button>
-        <mat-radio-button class="col" value="withoutFix">{{
+        <mat-radio-button class="col-3" value="withoutFix">{{
           'scan.WITHOUT_FIX' | translate
         }}</mat-radio-button>
-        <div class="col"></div>
+        <mat-radio-button class="col-4" value="withFixAll">{{
+          'scan.WITH_FIX_ALL' | translate
+        }}</mat-radio-button>
       </mat-radio-group>
     </section>
     <section class="row mx-0">
@@ -99,16 +101,16 @@
         aria-label="Profile"
         class="col row"
         formControlName="severityType">
-        <mat-radio-button class="col" value="all">{{
+        <mat-radio-button class="col-2" value="all">{{
           'setting.ALL' | translate
         }}</mat-radio-button>
-        <mat-radio-button class="col" value="high">{{
+        <mat-radio-button class="col-3" value="high">{{
           'enum.HIGH' | translate
         }}</mat-radio-button>
-        <mat-radio-button class="col" value="medium">{{
+        <mat-radio-button class="col-3" value="medium">{{
           'enum.MEDIUM' | translate
         }}</mat-radio-button>
-        <mat-radio-button class="col" value="low">{{
+        <mat-radio-button class="col-4" value="low">{{
           'enum.LOW' | translate
         }}</mat-radio-button>
       </mat-radio-group>

--- a/admin/webapp/websrc/assets/i18n/en-common.json
+++ b/admin/webapp/websrc/assets/i18n/en-common.json
@@ -1179,6 +1179,7 @@
     "PUBLISHED_TYPE": "Published Type",
     "WITH_FIX": "With Fix",
     "WITHOUT_FIX": "Without Fix",
+    "WITH_FIX_ALL": "With All Fixed",
     "INVALID_DATE": "Please input valid date.",
     "INVALID_DATE_RANGE": "Please input valid date range.",
     "CONDITION_HINT": "Sample: on Service use redis-pod.demo,nv.nvlab:node to matchredis-pod.demo or nv.nvlab:node service, same for the other criteria.",

--- a/admin/webapp/websrc/assets/i18n/zh_cn-common.json
+++ b/admin/webapp/websrc/assets/i18n/zh_cn-common.json
@@ -1179,6 +1179,7 @@
     "PUBLISHED_TYPE": "发布类型",
     "WITH_FIX": "修复",
     "WITHOUT_FIX": "未修复",
+    "WITH_FIX_ALL": "完全修复",
     "INVALID_DATE": "请输入有效的日期",
     "INVALID_DATE_RANGE": "请输入有效的日期范围",
     "CONDITION_HINT": "样本: 对于Namespace用redis-pod.demo,nv.nvlab:node去匹配matchredis-pod.demo或nv.nvlab:node服务, 其余同理",


### PR DESCRIPTION
Adds "With All Fixed" option to Vulnerabilities advanced filter. The behavior is:
- "With Fix" shows CVEs where any package contains a "Fix Version"
- "With All Fixed" shows CVEs where all packages contain a "Fix Version"
- "Without Fix" shows CVEs where all packages do not contain a "Fix Version"