### PR TITLE
Fix typo in java security properties param

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -16,5 +16,5 @@ exec java \
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens=java.base/java.util=ALL-UNNAMED \
-  -Djava.security.properties=="$JAVA_SECURITY_FILE" \
+  -Djava.security.properties="$JAVA_SECURITY_FILE" \
   -jar /usr/local/bin/admin-assembly-1.0.jar


### PR DESCRIPTION
Fixed double equal sign causing the intended java.security.properties not to be loaded. This error breaks running in FIPS mode but still allows it to work when not in FIPS mode.

Found a typo causing causing issues running in FIPS mode. The `-Djava.security.properties=="$JAVA_SECURITY_FILE"` in the entrypoint of the image has 2 `=` signs causing the FIPS java security properties to not be loaded properly. This seems to have been an issue introduced in dea13774786790c738fd4a58894597efd99274cb.

I also believe that this error causes the default properties not to be loaded either and just uses the jvm default properties instead of the one intended in the entrypoint script.

I also think this is the root cause of the following issue: https://github.com/neuvector/neuvector/issues/1757
