### PR TITLE
Revert "fix typo in java security properties param"

### DIFF
--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -16,5 +16,5 @@ exec java \
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens=java.base/java.util=ALL-UNNAMED \
-  -Djava.security.properties="$JAVA_SECURITY_FILE" \
+  -Djava.security.properties=="$JAVA_SECURITY_FILE" \
   -jar /usr/local/bin/admin-assembly-1.0.jar


### PR DESCRIPTION
This reverts commit 52f3d64801938d196a86bd7ad9490d0be71f7317.