### PR TITLE
NVSHAS-10178: [UI] Fed admission control's export dialog should not contain 'Include configurations' checkbox

### DIFF
--- a/admin/webapp/websrc/app/routes/components/admission-rules/partial/export-admission-rules-modal/export-admission-rules-modal.component.html
+++ b/admin/webapp/websrc/app/routes/components/admission-rules/partial/export-admission-rules-modal/export-admission-rules-modal.component.html
@@ -13,7 +13,7 @@
   </div>
   <hr class="fancy mb-2" />
   <form (ngSubmit)="submitExport()" [formGroup]="exportForm">
-    <div>
+    <div *ngIf="data.source !== GlobalConstant['NAV_SOURCE']['FED_POLICY']">
       <mat-checkbox class="mx-3" formControlName="isIncludingConfig">
         {{ 'admissionControl.CONFIG' | translate }}
       </mat-checkbox>

--- a/admin/webapp/websrc/app/routes/components/admission-rules/partial/export-admission-rules-modal/export-admission-rules-modal.component.ts
+++ b/admin/webapp/websrc/app/routes/components/admission-rules/partial/export-admission-rules-modal/export-admission-rules-modal.component.ts
@@ -17,6 +17,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
   styleUrls: ['./export-admission-rules-modal.component.scss'],
 })
 export class ExportAdmissionRulesModalComponent implements OnInit {
+  GlobalConstant = GlobalConstant;
   submittingForm = false;
   exportForm: FormGroup;
   exportFileName = GlobalConstant.REMOTE_EXPORT_FILENAME.ADMISSION_RULES;
@@ -52,7 +53,9 @@ export class ExportAdmissionRulesModalComponent implements OnInit {
       this.admissionRulesService
         .exportAdmissionRules(
           this.data.selectedAdmissionRules,
-          this.exportForm.controls.isIncludingConfig.value
+          this.exportForm.controls.isIncludingConfig.value,
+          null,
+          this.data.source
         )
         .pipe(
           finalize(() => {
@@ -84,7 +87,8 @@ export class ExportAdmissionRulesModalComponent implements OnInit {
         .exportAdmissionRules(
           this.data.selectedAdmissionRules,
           this.exportForm.controls.isIncludingConfig.value,
-          exportOptions
+          exportOptions,
+          this.data.source
         )
         .pipe(
           finalize(() => {


### PR DESCRIPTION
Removes checkbox from fed export dialog
Fixes bug with missing POST scope param on fed export

After:
<img width="1512" height="749" alt="Screenshot 2025-11-25 at 8 45 01 PM" src="https://github.com/user-attachments/assets/0909c451-f6a4-4854-910c-c6ddd191a3d8" />
