### PR TITLE
NVSHAS-10222 [Manager] After a cluster successfully joins fed, UI doesn't auto-refresh

### DIFF
--- a/admin/webapp/websrc/app/routes/multi-cluster/joining-modal/joining-modal.component.ts
+++ b/admin/webapp/websrc/app/routes/multi-cluster/joining-modal/joining-modal.component.ts
@@ -1,3 +1,4 @@
+import { GlobalConstant } from '@common/constants/global.constant';
 import { Component, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
@@ -107,7 +108,9 @@ export class JoiningModalComponent implements OnInit {
             switchMap(() => this.clustersService.getClusters()),
             filter((response: any) => {
               return (
-                response && response.fed_role && response.fed_role === 'joint'
+                response &&
+                response.fed_role &&
+                response.fed_role === GlobalConstant.CLUSTER_TYPES.MEMBER
               );
             }),
             take(1),


### PR DESCRIPTION
When a user joins a new cluster, the backend returns a 200 OK success response immediately. However, there is a latency window where the backend updates its internal cache. Previously, the UI attempted to fetch the cluster list with a fixed delay, which may result in stale data where fed_role was empty.

The Fix Replaced the static setTimeout approach with a polling mechanism. 

How to Verify
Open the Network tab in DevTools.

Perform a "Join Cluster" operation.

Observe that getCluster might be called multiple times (every 2s).

Verify that the UI only updates once the response contains a valid federation role (or hits the 20s timeout).