### PR TITLE
Feat: Allow web interface to serve content behind an optional URL path prefix

### DIFF
--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -93,15 +93,17 @@ trait Api extends Directives with CoreActors with Core {
   private val workloadApi       = new WorkloadApi(workloadService)
 
   val routes: Route = handleExceptions(exceptionHandler) {
-    authenticationApi.route ~
-    dashboardApi.route ~
-    clusterApi.route ~
-    deviceApi.route ~
-    groupApi.route ~
-    notificationApi.route ~
-    policyApi.route ~
-    riskApi.route ~
-    sigstoreApi.route ~
-    workloadApi.route
+    rawPathPrefix(sys.env.get("PATH_PREFIX").map(r => Slash ~ r).getOrElse("")) {
+      authenticationApi.route ~
+      dashboardApi.route ~
+      clusterApi.route ~
+      deviceApi.route ~
+      groupApi.route ~
+      notificationApi.route ~
+      policyApi.route ~
+      riskApi.route ~
+      sigstoreApi.route ~
+      workloadApi.route
+    }
   }
 }

--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -42,9 +42,9 @@ trait Api extends Directives with CoreActors with Core {
 
   private val managerPathPrefix: Option[String] =
     sys.env.get("PATH_PREFIX").map(_.trim).filter(_.nonEmpty)
-  private final val timeOutStatus              = "Status: 408"
-  private final val authenticationFailedStatus = "Status: 401"
-  private final val serverErrorStatus          = "Status: 503"
+  private final val timeOutStatus               = "Status: 408"
+  private final val authenticationFailedStatus  = "Status: 401"
+  private final val serverErrorStatus           = "Status: 503"
 
   implicit def exceptionHandler: ExceptionHandler =
     ExceptionHandler {

--- a/admin/src/main/scala/com/neu/api/Api.scala
+++ b/admin/src/main/scala/com/neu/api/Api.scala
@@ -40,6 +40,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
  */
 trait Api extends Directives with CoreActors with Core {
 
+  private val managerPathPrefix: Option[String] =
+    sys.env.get("PATH_PREFIX").map(_.trim).filter(_.nonEmpty)
   private final val timeOutStatus              = "Status: 408"
   private final val authenticationFailedStatus = "Status: 401"
   private final val serverErrorStatus          = "Status: 503"
@@ -93,7 +95,7 @@ trait Api extends Directives with CoreActors with Core {
   private val workloadApi       = new WorkloadApi(workloadService)
 
   val routes: Route = handleExceptions(exceptionHandler) {
-    rawPathPrefix(sys.env.get("PATH_PREFIX").map(r => Slash ~ r).getOrElse("")) {
+    rawPathPrefix(managerPathPrefix.map(r => Slash ~ r).getOrElse("")) {
       authenticationApi.route ~
       dashboardApi.route ~
       clusterApi.route ~

--- a/admin/src/main/scala/com/neu/web/StaticResources.scala
+++ b/admin/src/main/scala/com/neu/web/StaticResources.scala
@@ -29,7 +29,7 @@ trait StaticResources extends Directives with LazyLogging {
     }
   }
 
-  private val managerPathPrefixWithPrependedSlash: String    = _managerPathPrefixWithPrependedSlash
+  private val managerPathPrefixWithPrependedSlash: String = _managerPathPrefixWithPrependedSlash
 
   // # Rewrite redirect-implementation base on "spray/spray-routing/src/main/scala/spray/routing/RequestContext.scala, added strict transport security header"
   private def redirectMe(uri: Uri, redirectionType: StatusCodes.Redirection) =

--- a/admin/src/main/scala/com/neu/web/StaticResources.scala
+++ b/admin/src/main/scala/com/neu/web/StaticResources.scala
@@ -20,6 +20,17 @@ trait StaticResources extends Directives with LazyLogging {
   private val isUsingSSL: Boolean = sys.env.getOrElse("MANAGER_SSL", "on") == "on"
   private val isDev: Boolean      = sys.env.getOrElse("IS_DEV", "false") == "true"
 
+  private val _managerPathPrefixWithPrependedSlash: String = {
+    val rawPathOption: Option[String] = sys.env.get("PATH_PREFIX")
+
+    rawPathOption match {
+      case Some(value) => "/" + value.trim
+      case None        => ""
+    }
+  }
+
+  private val managerPathPrefixWithPrependedSlash: String    = _managerPathPrefixWithPrependedSlash
+
   // # Rewrite redirect-implementation base on "spray/spray-routing/src/main/scala/spray/routing/RequestContext.scala, added strict transport security header"
   private def redirectMe(uri: Uri, redirectionType: StatusCodes.Redirection) =
     complete {
@@ -42,60 +53,70 @@ trait StaticResources extends Directives with LazyLogging {
     }
 
   val staticResources: Route = get {
-    path("") {
-      redirectMe(
-        UrlEscapers
-          .urlFragmentEscaper()
-          .escape("/index.html?v=" + Md5.hash(managerVersion).take(shortPath)),
-        StatusCodes.MovedPermanently
-      )
-    } ~
-    path("index.html") {
-      parameters(Symbol("v").?) { v =>
-        val hash = Md5.hash(managerVersion).take(shortPath)
-        if (v.isEmpty) {
-          redirectMe(
-            UrlEscapers.urlFragmentEscaper().escape("/index.html?v=" + hash),
-            StatusCodes.MovedPermanently
-          )
-        } else {
-          if (v.get.equals(hash)) {
-            getFromResource("/index.html")
-          } else {
-            logger.info("Previous version hash: {}", v.get)
-            logger.info("Current version hash: {}", hash)
+    rawPathPrefix(sys.env.get("PATH_PREFIX").map(r => Slash ~ r).getOrElse("")) {
+      path("") {
+        redirectMe(
+          UrlEscapers
+            .urlFragmentEscaper()
+            .escape(
+              managerPathPrefixWithPrependedSlash + "/index.html?v=" + Md5
+                .hash(managerVersion)
+                .take(shortPath)
+            ),
+          StatusCodes.MovedPermanently
+        )
+      } ~
+      path("index.html") {
+        parameters(Symbol("v").?) { v =>
+          val hash = Md5.hash(managerVersion).take(shortPath)
+          if (v.isEmpty) {
             redirectMe(
-              UrlEscapers.urlFragmentEscaper().escape("/index.html?v=" + hash),
+              UrlEscapers
+                .urlFragmentEscaper()
+                .escape(managerPathPrefixWithPrependedSlash + "/index.html?v=" + hash),
               StatusCodes.MovedPermanently
             )
-          }
-        }
-      }
-    } ~
-    path("favicon.ico") {
-      Utils.respondWithWebServerHeaders(isStaticResource = true) {
-        complete(StatusCodes.NotFound)
-      }
-    } ~
-    path(Remaining) { path =>
-      if (isDev) {
-        Utils.respondWithWebServerHeaders(isStaticResource = true) {
-          getFromResource(UrlEscapers.urlFragmentEscaper().escape(s"root/$path"))
-        }
-      } else {
-        if (path.endsWith(".js")) {
-          Utils.respondWithWebServerHeaders(isStaticResource = true) {
-            respondWithHeader(RawHeader("Content-Type", "application/javascript")) {
-              encodeResponse {
-                getFromResource(
-                  UrlEscapers.urlFragmentEscaper().escape(s"root/$path.gz")
-                )
-              }
+          } else {
+            if (v.get.equals(hash)) {
+              getFromResource("/index.html")
+            } else {
+              logger.info("Previous version hash: {}", v.get)
+              logger.info("Current version hash: {}", hash)
+              redirectMe(
+                UrlEscapers
+                  .urlFragmentEscaper()
+                  .escape(managerPathPrefixWithPrependedSlash + "/index.html?v=" + hash),
+                StatusCodes.MovedPermanently
+              )
             }
           }
-        } else {
+        }
+      } ~
+      path("favicon.ico") {
+        Utils.respondWithWebServerHeaders(isStaticResource = true) {
+          complete(StatusCodes.NotFound)
+        }
+      } ~
+      path(Remaining) { path =>
+        if (isDev) {
           Utils.respondWithWebServerHeaders(isStaticResource = true) {
             getFromResource(UrlEscapers.urlFragmentEscaper().escape(s"root/$path"))
+          }
+        } else {
+          if (path.endsWith(".js")) {
+            Utils.respondWithWebServerHeaders(isStaticResource = true) {
+              respondWithHeader(RawHeader("Content-Type", "application/javascript")) {
+                encodeResponse {
+                  getFromResource(
+                    UrlEscapers.urlFragmentEscaper().escape(s"root/$path.gz")
+                  )
+                }
+              }
+            }
+          } else {
+            Utils.respondWithWebServerHeaders(isStaticResource = true) {
+              getFromResource(UrlEscapers.urlFragmentEscaper().escape(s"root/$path"))
+            }
           }
         }
       }

--- a/admin/src/main/scala/com/neu/web/StaticResources.scala
+++ b/admin/src/main/scala/com/neu/web/StaticResources.scala
@@ -24,7 +24,7 @@ trait StaticResources extends Directives with LazyLogging {
     val rawPathOption: Option[String] = sys.env.get("PATH_PREFIX")
 
     rawPathOption match {
-      case Some(value) => "/" + value.trim
+      case Some(value) => "/" + UrlEscapers.urlFragmentEscaper().escape(value.trim)
       case None        => ""
     }
   }

--- a/admin/src/main/scala/com/neu/web/StaticResources.scala
+++ b/admin/src/main/scala/com/neu/web/StaticResources.scala
@@ -19,9 +19,11 @@ trait StaticResources extends Directives with LazyLogging {
   private val shortPath           = 10
   private val isUsingSSL: Boolean = sys.env.getOrElse("MANAGER_SSL", "on") == "on"
   private val isDev: Boolean      = sys.env.getOrElse("IS_DEV", "false") == "true"
+  private val managerPathPrefix: Option[String] =
+    sys.env.get("PATH_PREFIX").map(_.trim).filter(_.nonEmpty)
 
   private val _managerPathPrefixWithPrependedSlash: String = {
-    val rawPathOption: Option[String] = sys.env.get("PATH_PREFIX")
+    val rawPathOption: Option[String] = managerPathPrefix
 
     rawPathOption match {
       case Some(value) => "/" + UrlEscapers.urlFragmentEscaper().escape(value.trim)
@@ -53,7 +55,7 @@ trait StaticResources extends Directives with LazyLogging {
     }
 
   val staticResources: Route = get {
-    rawPathPrefix(sys.env.get("PATH_PREFIX").map(r => Slash ~ r).getOrElse("")) {
+    rawPathPrefix(managerPathPrefix.map(r => Slash ~ r).getOrElse("")) {
       path("") {
         redirectMe(
           UrlEscapers

--- a/admin/src/main/scala/com/neu/web/StaticResources.scala
+++ b/admin/src/main/scala/com/neu/web/StaticResources.scala
@@ -16,9 +16,9 @@ import org.apache.pekko.http.scaladsl.server.Directives
 import org.apache.pekko.http.scaladsl.server.Route
 
 trait StaticResources extends Directives with LazyLogging {
-  private val shortPath           = 10
-  private val isUsingSSL: Boolean = sys.env.getOrElse("MANAGER_SSL", "on") == "on"
-  private val isDev: Boolean      = sys.env.getOrElse("IS_DEV", "false") == "true"
+  private val shortPath                         = 10
+  private val isUsingSSL: Boolean               = sys.env.getOrElse("MANAGER_SSL", "on") == "on"
+  private val isDev: Boolean                    = sys.env.getOrElse("IS_DEV", "false") == "true"
   private val managerPathPrefix: Option[String] =
     sys.env.get("PATH_PREFIX").map(_.trim).filter(_.nonEmpty)
 

--- a/admin/webapp/websrc/index.html
+++ b/admin/webapp/websrc/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>NeuVector</title>
-    <base href="/" />
     <meta
       content="width=device-width, initial-scale=1, maximum-scale=1"
       name="viewport" />


### PR DESCRIPTION
The Neuvector UI (manager) requires all traffic to be hosted at the root URL behind an FQDN. Although this fits most deployment scenarios, some users (me included) need to route traffic based on URL path prefixes. For example, instead of hosting at "https://neuvector.example.com/", I use "https://example.com/neuvector/".

This PR adds the necessary scaffolding to support a path prefix as described using the optional `PATH_PREFIX` environment variable. If unset, the Neuvector manager will continue to work as previous, serving at the root URL.

This environment variable must not contain a preceding slash.

To test, simply set the environment variable in your environment, and navigate to that new path (for example, if you usually navigate to `http://localhost:8443`, set the var to `test-path` and navigate to `http://localhost:8443/test-path/`).