### PR TITLE
chore: add new field for os_scan_status for container scan result

### DIFF
--- a/admin/src/main/scala/com/neu/model/Policy.scala
+++ b/admin/src/main/scala/com/neu/model/Policy.scala
@@ -119,7 +119,8 @@ case class ScanSummary(
   scanned_at: String,
   base_os: String,
   scanner_version: String,
-  cvedb_create_time: String
+  cvedb_create_time: String,
+  os_scan_status: Option[String]
 )
 
 case class IpAddress(

--- a/admin/src/main/scala/com/neu/model/PolicyJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/PolicyJsonProtocol.scala
@@ -226,7 +226,8 @@ object PolicyJsonProtocol extends DefaultJsonProtocol with LazyLogging {
           workload.scan_summary.scanned_at,
           workload.scan_summary.base_os,
           workload.scan_summary.scanner_version,
-          workload.scan_summary.cvedb_create_time
+          workload.scan_summary.cvedb_create_time,
+          workload.scan_summary.os_scan_status
         )
       )
     }
@@ -258,7 +259,8 @@ object PolicyJsonProtocol extends DefaultJsonProtocol with LazyLogging {
           workload.security.scan_summary.scanned_at,
           workload.security.scan_summary.base_os,
           workload.security.scan_summary.scanner_version,
-          workload.security.scan_summary.cvedb_create_time
+          workload.security.scan_summary.cvedb_create_time,
+          workload.security.scan_summary.os_scan_status
         )
       )
 


### PR DESCRIPTION
### Summary
NVSHAS-10257 will add new field for os_scan_status for container scan result scan to indicate if the os scan is either 
- unknown
- support
- unsupport