### PR TITLE
NVSHAS-10184: Fix auto-scan toggle behavior

### DIFF
--- a/admin/src/main/scala/com/neu/service/dashboard/DashboardService.scala
+++ b/admin/src/main/scala/com/neu/service/dashboard/DashboardService.scala
@@ -927,12 +927,7 @@ class DashboardService()(implicit executionContext: ExecutionContext)
 
   private lazy val getAutoScan = (
     autoScanConfig: AutoScanConfig
-  ) =>
-    autoScanConfig.config.enable_auto_scan_host.getOrElse(
-      autoScanConfig.config.auto_scan.getOrElse(false)
-    ) && autoScanConfig.config.enable_auto_scan_workload.getOrElse(
-      autoScanConfig.config.auto_scan.getOrElse(false)
-    )
+  ) => autoScanConfig.config.auto_scan.getOrElse(false)
 
   private lazy val getExposedConversation = (
     k: String,

--- a/admin/webapp/websrc/app/common/services/dashboard.service.ts
+++ b/admin/webapp/websrc/app/common/services/dashboard.service.ts
@@ -69,8 +69,7 @@ export class DashboardService {
 
   setAutoScan = (isAutoScan: boolean) => {
     return this.assetsHttpService.postScanConfig({
-      enable_auto_scan_host: isAutoScan,
-      enable_auto_scan_workload: isAutoScan,
+      auto_scan: isAutoScan,
     });
   };
 

--- a/admin/webapp/websrc/app/routes/containers/containers.component.ts
+++ b/admin/webapp/websrc/app/routes/containers/containers.component.ts
@@ -133,7 +133,9 @@ export class ContainersComponent implements OnInit, OnDestroy {
     this.scanService.getScanConfig().subscribe({
       next: (config: ScanConfig) => {
         this.autoScan.setValue(
-          config.enable_auto_scan_workload || (config.auto_scan as boolean)
+          config.enable_auto_scan_workload != null
+            ? config.enable_auto_scan_workload
+            : (config.auto_scan as boolean)
         );
         this.autoScanAuthorized = true;
       },

--- a/admin/webapp/websrc/app/routes/nodes/nodes.component.ts
+++ b/admin/webapp/websrc/app/routes/nodes/nodes.component.ts
@@ -112,7 +112,9 @@ export class NodesComponent implements OnInit, OnDestroy {
     this.scanService.getScanConfig().subscribe({
       next: (config: ScanConfig) => {
         this.autoScan.setValue(
-          config.enable_auto_scan_host || (config.auto_scan as boolean)
+          config.enable_auto_scan_host != null
+            ? config.enable_auto_scan_host
+            : (config.auto_scan as boolean)
         );
         this.autoScanAuthorized = true;
       },


### PR DESCRIPTION
Dashboard auto-scan toggle only POSTs `auto_scan` field
Nodes & Containers auto-scan toggle use `enable_auto_scan_host`/`enable_auto_scan_workload` if non-nil and fallback to `auto_scan` field