### PR TITLE
#1175, #1177

### DIFF
--- a/admin/webapp/package.json
+++ b/admin/webapp/package.json
@@ -63,7 +63,7 @@
     "jquery-sparkline": "2.4.0",
     "jquery.browser": "0.1.0",
     "jsoneditor": "^10.4.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "moment": "2.30.1",
     "ng2-charts": "3.0.8",
     "ng2-file-upload": "^9.0.0",
@@ -149,5 +149,8 @@
     "webpack": "^5.103.0",
     "webpack-dev-server": "^5.2.3",
     "zone.js": "^0.15.0"
+  },
+  "overrides": {
+    "lodash": "^4.18.0"
   }
 }

--- a/admin/webapp/websrc/app/common/neuvector-formly/icon-input/icon-input.component.html
+++ b/admin/webapp/websrc/app/common/neuvector-formly/icon-input/icon-input.component.html
@@ -3,10 +3,17 @@
   <mat-form-field
     [class]="to.isCell ? 'pull-left' : 'w-' + (to.inputWidth ?? '100')"
     [hideRequiredMarker]="to.hideRequiredMarker ?? false"
-    [floatLabel]="to.floatLabel ? 'always' : 'auto'">
+    [floatLabel]="
+      field.templateOptions?.prefix && field.templateOptions?.prefix.length > 0
+        ? 'always'
+        : to.floatLabel
+          ? 'always'
+          : 'auto'
+    ">
     <mat-label>{{ field.templateOptions?.label || '' | translate }}</mat-label>
     <span
       matPrefix
+      class="prefix-content"
       *ngIf="
         field.templateOptions?.prefix &&
         field.templateOptions?.prefix.length > 0
@@ -16,6 +23,11 @@
     <input
       *ngIf="field.templateOptions?.type !== 'number'; else numberTmp"
       [attr.disabled]="field.templateOptions?.disabled || false"
+      [ngClass]="{
+        'text-with-prefix':
+          field.templateOptions?.prefix &&
+          field.templateOptions?.prefix.length > 0,
+      }"
       [formControl]="formControl"
       [formlyAttributes]="field"
       [maskOnBlur]="field.templateOptions?.maskOnBlur"

--- a/admin/webapp/websrc/app/common/neuvector-formly/icon-input/icon-input.component.scss
+++ b/admin/webapp/websrc/app/common/neuvector-formly/icon-input/icon-input.component.scss
@@ -1,0 +1,8 @@
+.prefix-content {
+    position: absolute;
+    top: 4px;
+}
+
+.text-with-prefix {
+    padding-left: 20px;
+}


### PR DESCRIPTION
#1175 The 'fed' prefix and the registry name are not properly aligned when attempting to add a federated registr when attempting to add a federated registry to the primary cluster

Moved the prefix content to lower position
By default, show the field title as floating top style is there is prefix, no matter if there is value in the field


#1177 Upgrade lodash into v4.18.0 + to deal with the CVE-2026-4800