### PR TITLE
 #1183 [Bug] Auto Scan toggle state is not synchronized between Dashboard and Assets -> Nodes page

### DIFF
--- a/admin/src/main/scala/com/neu/model/PolicyJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/PolicyJsonProtocol.scala
@@ -39,7 +39,7 @@ object PolicyJsonProtocol extends DefaultJsonProtocol with LazyLogging {
     ApplicationListWrap.apply
   )
 
-  given scanConfigFormat: RootJsonFormat[ScanConfig]         = jsonFormat2(ScanConfig.apply)
+  given scanConfigFormat: RootJsonFormat[ScanConfig]         = jsonFormat3(ScanConfig.apply)
   given scanConfigWrapFormat: RootJsonFormat[ScanConfigWrap] = jsonFormat1(ScanConfigWrap.apply)
 
   given ruleConfigFormat: RootJsonFormat[RuleConfig]         = jsonFormat8(RuleConfig.apply)
@@ -290,6 +290,7 @@ object PolicyJsonProtocol extends DefaultJsonProtocol with LazyLogging {
 }
 
 case class ScanConfig(
+  auto_scan: Option[Boolean],
   enable_auto_scan_workload: Option[Boolean],
   enable_auto_scan_host: Option[Boolean]
 )


### PR DESCRIPTION
## Description

See #1183 

The ScanConfig Scala case class was missing the auto_scan field, causing the dashboard's PATCH to /v1/scan/config to silently drop the field. The dashboard auto scan toggle appeared to work but the state never
persisted on refresh.

## Test

 1. Navigate to the Dashboard and toggle Auto Scan OFF (or ON)
 2. Refresh the page
 3. Verify the toggle reflects the state you set