### PR TITLE
#1186 Missing critical CVE display in the exposure report on dashboard page

### DIFF
--- a/admin/webapp/websrc/app/routes/components/exposure-panel/exposure-panel.component.ts
+++ b/admin/webapp/websrc/app/routes/components/exposure-panel/exposure-panel.component.ts
@@ -143,6 +143,7 @@ export class ExposurePanelComponent implements OnInit {
           Direction: direction,
           Service: exposure.service,
           Pod: exposure.display_name,
+          'Critical Vuls': exposure.critical,
           'High Vuls': exposure.high,
           'Medium Vuls': exposure.medium,
           'Policy Mode': exposure.policy_mode,


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1186

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Open dashboard page and click exposure report button on the exposure panel
Observe if critial vuls column is added

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
