### PR TITLE
fix: image tag parsing for registry ports and digests

### DIFF
--- a/admin/webapp/websrc/app/common/services/containers.service.ts
+++ b/admin/webapp/websrc/app/common/services/containers.service.ts
@@ -209,6 +209,28 @@ export class ContainersService {
     return this.risksHttpService.getWorkloadsVulnerabilities(payload);
   }
 
+  private splitImageNameAndTag(imageRef?: string): {
+    image_name: string;
+    tags: string;
+  } {
+    if (!imageRef) {
+      return { image_name: '', tags: '' };
+    }
+
+    const [nameTagPart, digest] = imageRef.split('@');
+    const lastSlash = nameTagPart.lastIndexOf('/');
+    const lastColon = nameTagPart.lastIndexOf(':');
+
+    if (lastColon > lastSlash) {
+      return {
+        image_name: nameTagPart.slice(0, lastColon),
+        tags: digest || nameTagPart.slice(lastColon + 1),
+      };
+    }
+
+    return { image_name: nameTagPart, tags: digest || '' };
+  }
+
   private makeWorkloadData(w: Workload | WorkloadBrief, isChild: boolean) {
     let workload = w as Workload;
     return {
@@ -294,8 +316,9 @@ export class ContainersService {
     ].join(',');
 
     const csvRows = vulnerabilities.map(vul => {
-      const image_name = vul.workload_image?.split(':')[0] || '';
-      const tags = vul.workload_image?.split(':')[1] || '';
+      const { image_name, tags } = this.splitImageNameAndTag(
+        vul.workload_image
+      );
       const workload_name = vul.workload_name || '';
       const namespace = vul.workload_domain || '';
       const host_name = vul.host_name || vul.workload_host_name || '';


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/neuvector/manager/issues/1192

Fix container vulnerability CSV export parsing for image references that include registry ports and digests.

Previously, `workload_image` was split on `:`, which incorrectly treated registry ports as tags. For example, `127.0.0.1:31999/zarf-dev/zarf/agent:v0.74.2` was exported with `127.0.0.1` as the image name.

This change parses the image reference by only treating `:` as a tag separator when it appears after the final `/`. It also treats `@digest` as overriding the human-readable tag and places the digest in the `tags` field.

Below demonstrates the new behavior:
Input | image_name | tags
-- | -- | --
quay.io/foo/bar:v1 | quay.io/foo/bar | v1
quay.io/foo/bar@sha256:abc | quay.io/foo/bar | sha256:abc
quay.io/foo/bar:v1@sha256:abc | quay.io/foo/bar | sha256:abc (digest wins)
127.0.0.1:31999/repo/img:v1@sha256:abc | 127.0.0.1:31999/repo/img | sha256:abc
127.0.0.1:31999/repo/img | 127.0.0.1:31999/repo/img | 

## Test

I could not find existing tests so I tested and verified my changes locally using the same examples in the original issue linked above.

Testing with image digest:
<img width="753" height="103" alt="image" src="https://github.com/user-attachments/assets/f302bdae-2948-4ef4-8924-0baddef59946" />
<img width="799" height="56" alt="image" src="https://github.com/user-attachments/assets/7df6f45b-7193-4b61-8572-2004cd43cb8a" />

Testing with port in registry:
<img width="385" height="105" alt="image" src="https://github.com/user-attachments/assets/47161eff-3292-4a17-a838-9558596c0e3c" />
<img width="485" height="55" alt="image" src="https://github.com/user-attachments/assets/22e95295-464a-462c-a7d5-30f4ff4fbc0e" />

Testing with typical image + tag:
<img width="312" height="92" alt="image" src="https://github.com/user-attachments/assets/fcce23fe-3cda-4736-9311-c85e032b31fe" />
<img width="486" height="66" alt="image" src="https://github.com/user-attachments/assets/4d390266-5ed3-4d17-80ef-5b5529dc9222" />

## Additional Information

### Tradeoff

Digest references are placed in the existing tags column instead of adding a new CSV column, preserving the current CSV schema.

### Potential improvement

A future improvement could add dedicated unit tests for container image reference parsing if this service gains test coverage. I could not find existing tests so I tested and verified my changes locally.