### PR TITLE
#1166 add a column containing image digest in generated reports for containers

### DIFF
--- a/admin/webapp/websrc/app/common/services/containers.service.ts
+++ b/admin/webapp/websrc/app/common/services/containers.service.ts
@@ -209,6 +209,28 @@ export class ContainersService {
     return this.risksHttpService.getWorkloadsVulnerabilities(payload);
   }
 
+  private splitImageNameAndTag(imageRef?: string): {
+    image_name: string;
+    tags: string;
+  } {
+    if (!imageRef) {
+      return { image_name: '', tags: '' };
+    }
+
+    const [nameTagPart] = imageRef.split('@');
+    const lastSlash = nameTagPart.lastIndexOf('/');
+    const lastColon = nameTagPart.lastIndexOf(':');
+
+    if (lastColon > lastSlash) {
+      return {
+        image_name: nameTagPart.slice(0, lastColon),
+        tags: nameTagPart.slice(lastColon + 1),
+      };
+    }
+
+    return { image_name: nameTagPart, tags: '' };
+  }
+
   private makeWorkloadData(w: Workload | WorkloadBrief, isChild: boolean) {
     let workload = w as Workload;
     return {

--- a/admin/webapp/websrc/app/common/services/containers.service.ts
+++ b/admin/webapp/websrc/app/common/services/containers.service.ts
@@ -294,6 +294,7 @@ export class ContainersService {
     const header = [
       'image_name',
       'tags',
+      'digest',
       'workload_name',
       'namespace',
       'host_name',
@@ -316,8 +317,8 @@ export class ContainersService {
     ].join(',');
 
     const csvRows = vulnerabilities.map(vul => {
-      const image_name = vul.workload_image?.split(':')[0] || '';
-      const tags = vul.workload_image?.split(':')[1] || '';
+      const { image_name, tags } = this.splitImageNameAndTag(vul.workload_image);
+      const digest = vul.workload_image_digest || '';
       const workload_name = vul.workload_name || '';
       const namespace = vul.workload_domain || '';
       const host_name = vul.host_name || vul.workload_host_name || '';
@@ -350,6 +351,7 @@ export class ContainersService {
       return [
         image_name,
         tags,
+        digest,
         workload_name,
         namespace,
         host_name,


### PR DESCRIPTION
## Description

Fix #1166, Fix #1192

Adds a dedicated digest column to the container vulnerability scan report CSV export, and fixes image name/tag parsing for image references that include registry ports or digest-only refs.

## Test

1. Navigate to **Assets → Containers**
2. Download `Full Report` CSV
3. Verify the header row contains `digest`
4. Verify the digest column is populated from workload_image_digest in the API response (including empty case)
5. (for #1192) Verify image_name and tags are correctly split for images with registry ports (e.g. 127.0.0.1:31999/repo/img:v1)
