### PR TITLE
#1190 [Bug] hide global permissions from show advance setting's table

### DIFF
--- a/admin/webapp/websrc/app/common/constants/map.constant.ts
+++ b/admin/webapp/websrc/app/common/constants/map.constant.ts
@@ -289,6 +289,11 @@ export class MapConstant {
     MEMBER: 'joint',
     STANDALONE: '',
   };
+  public static ROLES_WITHOUT_ADV_SETTING = [
+    MapConstant.FED_ROLES.ADMIN,
+    MapConstant.FED_ROLES.FEDADMIN,
+    'ciops',
+  ];
   public static FED_PORT = {
     MASTER: 11443,
     JOINT: 10443,

--- a/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.html
@@ -109,7 +109,7 @@
       type="button"
       *ngIf="
         isKube &&
-        !['admin', 'fedAdmin', ''].includes(form.controls.role.value) &&
+        !hideAdvSettingButton &&
         !(data.isEdit && data.user!.server.toLowerCase().includes('rancher'))
       ">
       {{

--- a/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
@@ -48,10 +48,12 @@ export class AddEditUserDialogComponent implements OnInit {
     const role = this.form.controls.role.value;
     return (
       (this.toggleAdvSetting || role === '') &&
-      ![MapConstant.FED_ROLES.FEDADMIN, MapConstant.FED_ROLES.ADMIN].includes(
-        role
-      )
+      !MapConstant.ROLES_WITHOUT_ADV_SETTING.includes(role)
     );
+  }
+  get hideAdvSettingButton(): boolean {
+    const role = this.form.controls.role.value;
+    return [...MapConstant.ROLES_WITHOUT_ADV_SETTING, ''].includes(role);
   }
   @ViewChild(GroupDomainRoleTableComponent)
   domainTable!: GroupDomainRoleTableComponent;


### PR DESCRIPTION
## Description

Fixes #1190

Hide the "Show Advanced Setting" button and table in the Add/Edit User dialog when `ciops` is selected as the global role. The `ciops` role is plugin-scan only and has no use for namespace/domain permissions.
Added `ROLES_WITHOUT_ADV_SETTING` to MapConstant to centralize this exclusion list.

## Test

1. Go to **Settings → Users, API Keys & Roles → Users** tab
2. Click **Add User**
3. Select ciops in the Global Role dropdown
4. Verify the "Show Advanced Setting" button does not appear
