### PR TITLE
#1190 [Bug] hide global permissions from show advance setting's table

### DIFF
--- a/admin/src/main/scala/com/neu/model/AuthTokenJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/AuthTokenJsonProtocol.scala
@@ -24,9 +24,9 @@ object AuthTokenJsonProtocol extends DefaultJsonProtocol {
 
   given extraPermissionFormat: RootJsonFormat[ExtraPermission] = jsonFormat2(ExtraPermission.apply)
   given userFormat: RootJsonFormat[User]                       = jsonFormat16(User.apply)
-  given usersFormat: RootJsonFormat[Users]                     = jsonFormat3(Users.apply)
+  given usersFormat: RootJsonFormat[Users]                     = jsonFormat4(Users.apply)
   given userImageFormat: RootJsonFormat[UserImage]             = jsonFormat16(UserImage.apply)
-  given usersOutputFormat: RootJsonFormat[UsersOutput]         = jsonFormat3(UsersOutput.apply)
+  given usersOutputFormat: RootJsonFormat[UsersOutput]         = jsonFormat4(UsersOutput.apply)
   given selfWrapFormat: RootJsonFormat[SelfWrap]               = jsonFormat5(SelfWrap.apply)
   given userWrapFormat: RootJsonFormat[UserWrap]               = jsonFormat1(UserWrap.apply)
   given userTokenFormat: RootJsonFormat[UserToken]             = jsonFormat4(UserToken.apply)

--- a/admin/src/main/scala/com/neu/model/User.scala
+++ b/admin/src/main/scala/com/neu/model/User.scala
@@ -61,12 +61,14 @@ case class SelfWrap(
 case class Users(
   domain_roles: Option[Array[String]],
   global_roles: Option[Array[String]],
+  roles_not_for_domain: Option[Array[String]],
   users: Array[User]
 )
 
 case class UsersOutput(
   domain_roles: Option[Array[String]],
   global_roles: Option[Array[String]],
+  roles_not_for_domain: Option[Array[String]],
   users: Array[UserImage]
 )
 

--- a/admin/src/main/scala/com/neu/service/authentication/ExtraAuthService.scala
+++ b/admin/src/main/scala/com/neu/service/authentication/ExtraAuthService.scala
@@ -208,6 +208,7 @@ class ExtraAuthService() extends BaseService with DefaultJsonFormats with LazyLo
         UsersOutput(
           users.domain_roles,
           users.global_roles,
+          users.roles_not_for_domain,
           userImage
         )
       } catch {

--- a/admin/webapp/websrc/app/common/constants/map.constant.ts
+++ b/admin/webapp/websrc/app/common/constants/map.constant.ts
@@ -289,11 +289,6 @@ export class MapConstant {
     MEMBER: 'joint',
     STANDALONE: '',
   };
-  public static ROLES_WITHOUT_ADV_SETTING = [
-    MapConstant.FED_ROLES.ADMIN,
-    MapConstant.FED_ROLES.FEDADMIN,
-    'ciops',
-  ];
   public static FED_PORT = {
     MASTER: 11443,
     JOINT: 10443,

--- a/admin/webapp/websrc/app/common/types/settings/settings.ts
+++ b/admin/webapp/websrc/app/common/types/settings/settings.ts
@@ -158,6 +158,7 @@ export interface ServerPatchBody {
 export interface UserGetResponse {
   domain_roles: string[];
   global_roles: string[];
+  roles_not_for_domain: string[];
   users: User[];
 }
 

--- a/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
@@ -26,6 +26,7 @@ export interface AddEditUserDialog {
   isEdit: boolean;
   globalRoles: string[];
   domainRoles: string[];
+  rolesNotForDomain: string[];
   domains: string[];
   user?: User;
   isReadOnly?: boolean;
@@ -44,16 +45,26 @@ export class AddEditUserDialogComponent implements OnInit {
   saving$ = new Subject();
   toggleAdvSetting = false;
   domainTableSource!: MatTableDataSource<any>;
-  get showAdvSetting() {
+
+  private get isRoleWithoutDomainScope(): boolean {
     const role = this.form.controls.role.value;
-    return (
-      (this.toggleAdvSetting || role === '') &&
-      !MapConstant.ROLES_WITHOUT_ADV_SETTING.includes(role)
-    );
+    return [
+      MapConstant.FED_ROLES.ADMIN,
+      MapConstant.FED_ROLES.FEDADMIN,
+      ...this.data.rolesNotForDomain,
+    ].includes(role);
   }
+
+  get showAdvSetting(): boolean {
+    if (this.isRoleWithoutDomainScope) return false;
+    const role = this.form.controls.role.value;
+    if (role === '') return true;
+    return this.toggleAdvSetting;
+  }
+
   get hideAdvSettingButton(): boolean {
     const role = this.form.controls.role.value;
-    return [...MapConstant.ROLES_WITHOUT_ADV_SETTING, ''].includes(role);
+    return role === '' || this.isRoleWithoutDomainScope;
   }
   @ViewChild(GroupDomainRoleTableComponent)
   domainTable!: GroupDomainRoleTableComponent;

--- a/admin/webapp/websrc/app/routes/components/users-grid/users-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/users-grid/users-grid.component.ts
@@ -62,6 +62,7 @@ export class UsersGridComponent implements OnInit {
   }
   @Input() globalRoles!: string[];
   @Input() domainRoles!: string[];
+  @Input() rolesNotForDomain: string[] = [];
   get rowData() {
     return this._rowData;
   }
@@ -251,6 +252,7 @@ export class UsersGridComponent implements OnInit {
         isEdit: false,
         globalRoles: this.globalRoles,
         domainRoles: this.domainRoles,
+        rolesNotForDomain: this.rolesNotForDomain,
         domains: this.domains,
       },
     });
@@ -308,6 +310,7 @@ export class UsersGridComponent implements OnInit {
         user: event.data,
         globalRoles: this.globalRoles,
         domainRoles: this.domainRoles,
+        rolesNotForDomain: this.rolesNotForDomain,
         domains: this.domains,
       },
     });
@@ -400,6 +403,7 @@ export class UsersGridComponent implements OnInit {
         user: event.data,
         globalRoles: this.globalRoles,
         domainRoles: this.domainRoles,
+        rolesNotForDomain: this.rolesNotForDomain,
         domains: this.domains,
       },
     });

--- a/admin/webapp/websrc/app/routes/settings/users/users.component.html
+++ b/admin/webapp/websrc/app/routes/settings/users/users.component.html
@@ -15,6 +15,7 @@
           [userData]="userData"
           [globalRoles]="globalRoles"
           [domainRoles]="domainRoles"
+          [rolesNotForDomain]="rolesNotForDomain"
           (refreshData)="refreshUsers()"></app-users-grid>
       </ng-container>
     </mat-tab>

--- a/admin/webapp/websrc/app/routes/settings/users/users.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/users/users.component.ts
@@ -23,9 +23,11 @@ export class UsersComponent implements OnInit {
   error: unknown;
   globalRoles!: string[];
   domainRoles!: string[];
+  rolesNotForDomain!: string[];
   users$ = this.settingsService.getUsers().pipe(
     tap(user => {
       this.domainRoles = user.domain_roles;
+      this.rolesNotForDomain = user.roles_not_for_domain || [];
       if (!this.authUtils.userPermission.isNamespaceUser) {
         this.globalRoles = user.global_roles;
       } else {


### PR DESCRIPTION
## Description

Fix #1190

## Test

1. Navigate to **Settings → Users** and open the **Add** user dialog
2. Select a role listed in `roles_not_for_domain` (e.g. ciops) — the Show advanced setting button should be hidden
3. Select a role not in `roles_not_for_domain` (e.g. reader) — the button should appear