### PR TITLE
feat: add CVE DB version, timestamps, image digest and including images without vul to vulnerability reports

### DIFF
--- a/admin/src/main/scala/com/neu/api/risk/RiskApi.scala
+++ b/admin/src/main/scala/com/neu/api/risk/RiskApi.scala
@@ -101,12 +101,12 @@ class RiskApi(resourceService: RiskService) extends BaseApi {
               pathEnd {
                 patch {
                   parameter(Symbol("queryToken").?) { queryToken =>
-                    entity(as[TimeRange]) { timeRange =>
+                    entity(as[VulnerabilityAssetQuery]) { assetQuery =>
                       Utils.respondWithWebServerHeaders() {
                         resourceService.queryCveAssetsView(
                           tokenId,
                           queryToken,
-                          timeRange
+                          assetQuery
                         )
                       }
                     }

--- a/admin/src/main/scala/com/neu/model/Vulnerability.scala
+++ b/admin/src/main/scala/com/neu/model/Vulnerability.scala
@@ -65,3 +65,8 @@ case class TimeRange(
 case class ScannedAssetsQuery(
   `type`: String
 )
+
+case class VulnerabilityAssetQuery(
+  last_modified_timestamp: Long,
+  include_no_vul_assets: Option[Boolean] = Some(false)
+)

--- a/admin/src/main/scala/com/neu/model/VulnerabilityJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/VulnerabilityJsonProtocol.scala
@@ -38,6 +38,9 @@ object VulnerabilityJsonProtocol extends DefaultJsonProtocol {
   given timeRangeFormat: RootJsonFormat[TimeRange] =
     jsonFormat1(TimeRange.apply)
 
+  given vulnerabilityAssetQueryFormat: RootJsonFormat[VulnerabilityAssetQuery] =
+    jsonFormat2(VulnerabilityAssetQuery.apply)
+
   given scannedAssetsQueryFormat: RootJsonFormat[ScannedAssetsQuery] = jsonFormat1(
     ScannedAssetsQuery.apply
   )
@@ -59,6 +62,8 @@ object VulnerabilityJsonProtocol extends DefaultJsonProtocol {
   def timeRangeToJson(
     timeRange: TimeRange
   ): String = timeRange.toJson.compactPrint
+  def vulnerabilityAssetQueryToJson(query: VulnerabilityAssetQuery): String                =
+    query.toJson.compactPrint
   def remoteExportOptionsToJson(remoteExportOptions: RemoteExportOptions): String          =
     remoteExportOptions.toJson.compactPrint
   def scannedAssetsQueryToJson(query: ScannedAssetsQuery): String                          = query.toJson.compactPrint

--- a/admin/src/main/scala/com/neu/service/risk/RiskService.scala
+++ b/admin/src/main/scala/com/neu/service/risk/RiskService.scala
@@ -134,7 +134,7 @@ class RiskService extends BaseService with DefaultJsonFormats with LazyLogging {
   def queryCveAssetsView(
     tokenId: String,
     queryToken: Option[String],
-    timeRange: TimeRange
+    query: VulnerabilityAssetQuery
   ): Route = {
     val url = queryToken.fold(
       s"${baseClusterUri(tokenId)}/assetvul"
@@ -145,7 +145,7 @@ class RiskService extends BaseService with DefaultJsonFormats with LazyLogging {
       RestClient.httpRequestWithHeader(
         url,
         POST,
-        timeRangeToJson(timeRange),
+        vulnerabilityAssetQueryToJson(query),
         tokenId
       )
     }

--- a/admin/webapp/websrc/app/common/api/risks-http.service.ts
+++ b/admin/webapp/websrc/app/common/api/risks-http.service.ts
@@ -145,10 +145,13 @@ export class RisksHttpService {
     );
   }
 
-  postAssetsViewData(queryToken: string, lastModifiedTime: number) {
+  postAssetsViewData(queryToken: string, lastModifiedTime: number, includeNoVulAssets: boolean = false) {
     return GlobalVariable.http.patch<any>(
       PathConstant.ASSETS_VULS_URL,
-      { last_modified_timestamp: lastModifiedTime },
+      {
+        last_modified_timestamp: lastModifiedTime,
+        include_no_vul_assets: includeNoVulAssets
+      },
       { params: { queryToken: queryToken } }
     );
   }

--- a/admin/webapp/websrc/app/routes/components/security-risk-printable-report/assets-view-report/assets-view-report-assets-images-table/assets-view-report-assets-images-table.component.html
+++ b/admin/webapp/websrc/app/routes/components/security-risk-printable-report/assets-view-report/assets-view-report-assets-images-table/assets-view-report-assets-images-table.component.html
@@ -24,6 +24,12 @@
         *ngIf="reportPage === 'vulnerabilities'"
         class="print-cell"
         style="width: 10%">
+        {{ 'scan.report.gridHeader.CVE_DB_VERSION' | translate }}
+      </th>
+      <th
+        *ngIf="reportPage === 'vulnerabilities'"
+        class="print-cell"
+        style="width: 10%">
         {{ 'scan.report.gridHeader.HI_MED' | translate }}
       </th>
       <th
@@ -55,7 +61,21 @@
       "
       [attr.data-index]="i">
       <td class="print-cell" style="width: 30%">
-        {{ reportPage === 'vulnerabilities' ? image.name : image.image_name }}
+        <div>{{ reportPage === 'vulnerabilities' ? image.name : image.image_name }}</div>
+        <div *ngIf="reportPage === 'vulnerabilities'" class="text-muted small" style="word-break: break-all;">
+          {{ image.digest }}
+        </div>
+      </td>
+      <td
+        *ngIf="reportPage === 'vulnerabilities'"
+        class="print-cell" style="width: 10%">
+        <div>{{ image.cvedb_version }}</div>
+        <div class="text-muted small">
+          {{ 'scan.report.gridHeader.CVE_DB_LAST_UPDATED' | translate }}
+        </div>
+        <div class="text-muted small">
+          {{ image.cvedb_create_time | date:'yyyy-MM-dd HH:mm:ss' }}
+        </div>
       </td>
       <td
         *ngIf="reportPage === 'vulnerabilities'"
@@ -76,19 +96,18 @@
         *ngIf="reportPage === 'vulnerabilities'"
         class="print-cell"
         style="width: 60%">
-        <div *ngIf="image.critical + image.high + image.medium + image.low > 0">
+        <ng-container *ngIf="image.critical + image.high + image.medium + image.low > 0; else noVulns">
           <span
             *ngFor="let item of image.vulnerabilities"
             class="margin-right-s text-{{ item.split('_')[0] }}">
             {{ item.split('_')[1].trim() }}
           </span>
-        </div>
-        <div
-          *ngIf="image.critical + image.high + image.medium + image.low === 0">
+        </ng-container>
+        <ng-template #noVulns>
           <span class="text-success">{{
             'scan.NO_VULNERABILITIES' | translate
           }}</span>
-        </div>
+        </ng-template>
       </td>
       <td
         *ngIf="reportPage === 'compliance'"

--- a/admin/webapp/websrc/app/routes/components/security-risk-printable-report/risks-view-report/risk-view-report-impact-col/risk-view-report-impact-col.component.html
+++ b/admin/webapp/websrc/app/routes/components/security-risk-printable-report/risks-view-report/risk-view-report-impact-col/risk-view-report-impact-col.component.html
@@ -29,7 +29,11 @@
     <strong>{{ 'scan.report.data.IMAGES' | translate }}</strong>
   </div>
   <div *ngFor="let image of images | slice: 0 : 5">
-    {{ image.display_name }}
+    <div>{{ image.display_name }}</div>
+
+    <div class="text-muted small" style="word-break: break-all; line-height: 1.2;">
+      {{ image.digest }}
+    </div>
   </div>
 </div>
 <div *ngIf="images && Array.isArray(images) && images.length > 5">

--- a/admin/webapp/websrc/app/routes/vulnerabilities/pdf-generation-dialog/pdf-generation-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/pdf-generation-dialog/pdf-generation-dialog.component.html
@@ -44,13 +44,24 @@
     </ng-container>
   </div>
   <div *ngIf="data.isPdf">
-    <mat-checkbox
-      class="mt-1"
-      style="margin-left: 12px"
-      formControlName="withoutAppendix"
-      labelPosition="after">
-      {{ 'scan.WITHOUT_APPENDIX' | translate }}
-    </mat-checkbox>
+    <div>
+      <mat-checkbox
+        class="mt-1"
+        style="margin-left: 12px"
+        formControlName="withoutAppendix"
+        labelPosition="after">
+        {{ 'scan.WITHOUT_APPENDIX' | translate }}
+      </mat-checkbox>
+    </div>
+    <div *ngIf="data.isAssetsView">
+      <mat-checkbox
+        class="mt-1"
+        style="margin-left: 12px"
+        formControlName="includeNoVulAssets"
+        labelPosition="after">
+        {{ 'scan.INCLUDE_ALL_SCANNED_IMAGES' | translate }}
+      </mat-checkbox>
+    </div>
   </div>
   <div class="d-flex justify-content-end">
     <app-loading-button

--- a/admin/webapp/websrc/app/routes/vulnerabilities/pdf-generation-dialog/pdf-generation-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/pdf-generation-dialog/pdf-generation-dialog.component.ts
@@ -38,6 +38,7 @@ export class PdfGenerationDialogComponent {
       Validators.required
     ),
     withoutAppendix: new FormControl(false),
+    includeNoVulAssets: new FormControl(false),
   });
   saving$ = new Subject();
   get customDate(): Date {
@@ -52,6 +53,10 @@ export class PdfGenerationDialogComponent {
 
   get withoutAppendix(): boolean {
     return this.form.get('withoutAppendix')?.value || false;
+  }
+
+  get includeNoVulAssets(): boolean {
+    return this.form.get('includeNoVulAssets')?.value || false;
   }
 
   constructor(
@@ -69,6 +74,7 @@ export class PdfGenerationDialogComponent {
     this.submitDate.emit({
       date: this.getDate(this.selectedDateOption, this.customDate),
       withoutAppendix: this.withoutAppendix,
+      includeNoVulAssets: this.includeNoVulAssets,
     });
   }
 

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
@@ -188,30 +188,21 @@ export class VulnerabilitiesComponent implements OnDestroy {
       data: {
         pdf_name: this.tr.instant('scan.report.PDF_LINK2'),
         isPdf: true,
+        isAssetsView: true,
       },
     });
     dialogRef.componentInstance.submitDate.subscribe(params => {
-      if (params.date) {
-        this.getAssetsViewReportData(
-          this.vulnerabilitiesService.activeToken,
-          this.exportAssetsViewPdfFile,
-          dialogRef,
-          {
-            lastModifiedTime: params.date.getTime() / 1000,
-            withoutAppendix: params.withoutAppendix,
-          }
-        );
-      } else {
-        this.getAssetsViewReportData(
-          this.vulnerabilitiesService.activeToken,
-          this.exportAssetsViewPdfFile,
-          dialogRef,
-          {
-            lastModifiedTime: 0,
-            withoutAppendix: params.withoutAppendix,
-          }
-        );
-      }
+      const lastModifiedTime = params.date ? params.date.getTime() / 1000 : 0;
+      this.getAssetsViewReportData(
+        this.vulnerabilitiesService.activeToken,
+        this.exportAssetsViewPdfFile,
+        dialogRef,
+        {
+          lastModifiedTime: lastModifiedTime,
+          withoutAppendix: params.withoutAppendix,
+          includeNoVulAssets: params.includeNoVulAssets
+        }
+      );
     });
   };
 
@@ -243,7 +234,10 @@ export class VulnerabilitiesComponent implements OnDestroy {
   ) => {
     this.withoutAppendix = options.withoutAppendix;
     this.vulnerabilitiesService
-      .getAssetsViewReportData(queryToken, options.lastModifiedTime)
+      .getAssetsViewReportData(
+        queryToken,
+        options.lastModifiedTime,
+        options.includeNoVulAssets)
       .subscribe(
         (response: any) => {
           cb(response, dialogRef);
@@ -276,11 +270,15 @@ export class VulnerabilitiesComponent implements OnDestroy {
 
   private exportAssetsViewPdfFile = (data: any, dialogRef) => {
     console.log('Assets View data()PDF: ', data);
+    const combinedImages = [
+      ...(data.images || []),
+      ...(data.no_vul_images || [])
+    ];
     this.masterGrids = [
       data.workloads,
       data.nodes,
       data.platforms,
-      data.images,
+      combinedImages,
     ];
     this.vulnerabilitiesList = data.vulnerabilities;
     dialogRef.componentInstance.saving$.next(false);

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.service.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.service.ts
@@ -283,11 +283,11 @@ export class VulnerabilitiesService {
 
   getAssetsViewReportData(
     queryToken: string,
-    lastModifiedTime: number
+    lastModifiedTime: number,
+    includeNoVulAssets: boolean = false
   ): Observable<any> {
     return this.risksHttpService
-      .postAssetsViewData(queryToken, lastModifiedTime)
-      .pipe();
+      .postAssetsViewData(queryToken, lastModifiedTime, includeNoVulAssets);
   }
 
   getDomain(): Observable<string[]> {

--- a/admin/webapp/websrc/assets/i18n/en-common.json
+++ b/admin/webapp/websrc/assets/i18n/en-common.json
@@ -1181,6 +1181,7 @@
     "PROTECTED_CONTAINER": "Protected container",
     "LAST_MODIFIED": "Last Modified",
     "WITHOUT_APPENDIX": "Without Appendix",
+    "INCLUDE_ALL_SCANNED_IMAGES": "Include all scanned images (including those without vulnerabilities)",
     "PUBLISHED": "Published",
     "PUBLISHED_TYPE": "Published Type",
     "WITH_FIX": "With Fix",
@@ -1221,7 +1222,9 @@
         "PACKAGE": "Package",
         "PACKAGES": "Packages",
         "IMPACT": "Impact",
-        "HI_MED": "Critical/High/Medium"
+        "HI_MED": "Critical/High/Medium",
+        "CVE_DB_VERSION": "CVE DB Version",
+        "CVE_DB_LAST_UPDATED": "DB Updated:"
       },
       "data": {
         "V2": "V2",

--- a/admin/webapp/websrc/assets/i18n/zh_cn-common.json
+++ b/admin/webapp/websrc/assets/i18n/zh_cn-common.json
@@ -1180,6 +1180,7 @@
     "PROTECTED_CONTAINER": "被保护的容器",
     "LAST_MODIFIED": "上一次更改",
     "WITHOUT_APPENDIX": "不打印附表",
+    "INCLUDE_ALL_SCANNED_IMAGES": "包含所有扫描的镜像（包括无漏洞的镜像）",
     "PUBLISHED": "发布时间",
     "PUBLISHED_TYPE": "发布类型",
     "WITH_FIX": "修复",
@@ -1220,7 +1221,9 @@
         "PACKAGE": "包",
         "PACKAGES": "包",
         "IMPACT": "影响",
-        "HI_MED": "极危/高危/中危"
+        "HI_MED": "极危/高危/中危",
+        "CVE_DB_VERSION": "CVE 数据库版本",
+        "CVE_DB_LAST_UPDATED": "数据库更新时间："
       },
       "data": {
         "V2": "V2",


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix 
#1159 Include CVE DB Version in NeuVector Vulnerability Report
#1189 Add DB timestamp and no vulnerability assets

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

1. Navigate to the Security Risks -> Vulnerabilities page.

2. Open the Print Assets View PDF dialog.

3. Verify that the "Include all scanned images" checkbox appears only for Assets View.

4. Generate the report and confirm:

- Images display their full SHA digest
- The CVE DB Version and DB installed DateTime are present.
- Images without vulnerabilities are listed with the text "No vulnerabilities found" if user checks the "Include all scanned image" checkbox

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
<img width="1660" height="778" alt="Screenshot 2026-05-13 at 7 15 22 PM" src="https://github.com/user-attachments/assets/19d8787f-c006-4001-81b8-34d278f2e1e2" />
<img width="742" height="349" alt="Screenshot 2026-05-13 at 7 15 01 PM" src="https://github.com/user-attachments/assets/dd6b3907-1488-45bd-926f-ddcfafec80c7" />
<img width="739" height="537" alt="Screenshot 2026-05-13 at 10 50 15 PM" src="https://github.com/user-attachments/assets/c30fbd39-c2bb-4686-8f61-e0f3f14120b7" />
