### PR TITLE
#1206 Assets > Registry -> Interval bar cannot be scrolled on UI

### DIFF
--- a/admin/webapp/websrc/app/common/neuvector-formly/slider/slider.component.html
+++ b/admin/webapp/websrc/app/common/neuvector-formly/slider/slider.component.html
@@ -2,14 +2,16 @@
   field.templateOptions?.label ?? '' | translate
 }}</label>
 <mat-slider
-  (input)="changeValue($event)"
   [attr.aria-labelledby]="field.templateOptions?.id"
-  [formControl]="formControl"
   [formlyAttributes]="field"
   [max]="field.templateOptions?.max"
   [min]="field.templateOptions?.min"
   [step]="field.templateOptions?.step"
   class="mx-2">
+  <input
+    matSliderThumb
+    [formControl]="formControl"
+    (input)="changeValue($event)" />
 </mat-slider>
 <span>{{
   field.templateOptions?.stepValues

--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table-buttons/registries-table-buttons.component.html
@@ -12,7 +12,7 @@
     matTooltip="{{ 'registry.TIP.EDIT' | translate }}"
     matTooltipPosition="above"
     mat-icon-button>
-    <i class="eos-icons">edit</i>
+    <mat-icon fontSet="eos-icons">edit</mat-icon>
   </button>
   <button
     (click)="delete()"
@@ -20,7 +20,7 @@
     matTooltip="{{ 'registry.TIP.DELETE' | translate }}"
     matTooltipPosition="above"
     mat-icon-button>
-    <i class="eos-icons">delete</i>
+    <mat-icon fontSet="eos-icons">delete</mat-icon>
   </button>
 </div>
 <button


### PR DESCRIPTION
## Description

Fix #1206

After fix: 
<img width="658" height="128" alt="Screenshot 2026-05-18 at 2 25 11 PM" src="https://github.com/user-attachments/assets/5b158943-0d36-4601-802d-e0353819d975" />

## Test

1. Navigate to **Assets → Registries**
2. Open the Add or Edit registry dialog
3. Enable **Periodic Scan**
4. Drag the **Interval** slider — it should now move and update the displayed value correctly with no console errors