### PR TITLE
 #1227 automatically convert remaining namespace text into a tag on blur

### DIFF
--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
@@ -175,6 +175,7 @@
           <input
             #namespaceInput
             (matChipInputTokenEnd)="add($event)"
+            (blur)="addOnBlur()"
             [formControl]="namespaceCtrl"
             [matAutocomplete]="auto"
             [matChipInputFor]="chipList"

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.ts
@@ -263,6 +263,23 @@ export class VulnerabilityItemsTableFilterComponent implements OnInit {
     }
   }
 
+  addOnBlur(): void {
+    const inputElement = this.namespaceInput.nativeElement;
+    const value = (inputElement.value || '').trim();
+
+    if(!this.autocompleteTagsOptionActivated && value) {
+      const currentDomains = this.form.controls.selectedDomains.value || [];
+
+      if (!currentDomains.includes(value)) {
+        currentDomains.push(value);
+        this.form.controls.selectedDomains.setValue(currentDomains);
+      }
+
+      inputElement.value = '';
+      this.namespaceCtrl.setValue(null);
+    }
+  }
+
   private _filter(value: string): string[] {
     const filterValue = value.toLowerCase();
     return this.data.domains


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1227

Fixed an issue in the Advanced Filter dialog box where typed text in the Domains/Namespaces input field was ignored and omitted from the selectedDomains payload if the user clicked "Apply" without pressing Enter first.

Added a blur event listener to the input element that invokes an addOnBlur() handler, transforming input text into a tag.

## Test

1. Open the Vulnerabilities page -> Click the Advanced Filter to open the filter dialog box

2. Type a namespace name (e.g., production) without pressing the Enter

3. Click into another field or click the Apply button

4. Expected behavior: The typed text (e.g. production) should convert into a tag inside the field

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->


https://github.com/user-attachments/assets/16cff245-e83a-4a85-9fe0-a43041b7bf76

