### PR TITLE
#1226 In Vulnerabilities page, the Vulnerability view filter and Advanced filter do not connecting with each other

### DIFF
--- a/admin/webapp/websrc/app/common/utils/common.utils.ts
+++ b/admin/webapp/websrc/app/common/utils/common.utils.ts
@@ -36,6 +36,8 @@ let CALENDAR: any = {
   SECONDS: 'seconds',
 };
 
+export const SEVERITY_SORT_ORDER = ['low', 'medium', 'high', 'critical'];
+
 export const FEED_RATING_SORT_ORDER = [
   'untriaged',
   'not yet assigned',

--- a/admin/webapp/websrc/app/routes/components/vulnerabilities-grid/vulnerabilities-grid.component.ts
+++ b/admin/webapp/websrc/app/routes/components/vulnerabilities-grid/vulnerabilities-grid.component.ts
@@ -23,6 +23,7 @@ import { GlobalVariable } from '@common/variables/global.variable';
 import { UtilsService } from '@common/utils/app.utils';
 import {
   FEED_RATING_SORT_ORDER,
+  SEVERITY_SORT_ORDER,
   capitalizeWord,
 } from '@common/utils/common.utils';
 import { VulnerabilityItemsTableScoreCellComponent } from '@routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-score-cell/vulnerability-items-table-score-cell.component';
@@ -59,6 +60,9 @@ export class VulnerabilitiesGridComponent implements OnInit, OnChanges {
       field: 'severity',
       cellRenderer: 'severityCellRenderer',
       cellClass: ['d-flex', 'align-items-center'],
+      comparator: (value1, value2) =>
+        SEVERITY_SORT_ORDER.indexOf((value1 || '').toLowerCase()) -
+        SEVERITY_SORT_ORDER.indexOf((value2 || '').toLowerCase()),
       headerValueGetter: () =>
         this.translate.instant('scan.gridHeader.SEVERITY'),
       width: 130,

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
@@ -64,9 +64,15 @@ export class VulnerabilitiesComponent implements OnDestroy {
 
   changeSelectedView(view: VulnerabilityView) {
     this.selectedView = view;
+    const isAssetView = view === 'infrastructure' || view === 'registry';
     this.vulnerabilitiesFilterService.vulQuerySubject$.next({
       ...this.vulnerabilitiesFilterService.vulQuerySubject$.value,
       viewType: this.selectedView,
+      ...(isAssetView && {
+        serviceName: '',
+        containerName: '',
+        selectedDomains: [],
+      }),
     });
     setTimeout(() => {
       this.refresh();

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.html
@@ -143,7 +143,7 @@
           formControlName="scoreV2"></ngx-slider>
       </div>
     </section>
-    <section class="row mx-0 align-items-center">
+    <section class="row mx-0 align-items-center" *ngIf="!isAssetView">
       <label class="col-2 font-weight-normal mb-0" for="namespaceInput">{{
         'ldap.gridHeader.DOMAINS' | translate
       }}</label>
@@ -198,7 +198,7 @@
         {{ viewText }}&nbsp;<i class="eos-icons">arrow_drop_down</i>
       </button>
       <mat-menu #menu="matMenu">
-        <button (click)="changeView(0)" mat-menu-item>
+        <button (click)="changeView(0)" mat-menu-item *ngIf="!isAssetView">
           <span>{{ 'admissionControl.names.SERVICE' | translate }}</span>
         </button>
         <button
@@ -213,7 +213,7 @@
           *ngIf="form.controls.selectedDomains.value.length === 0">
           <span>{{ 'admissionControl.names.NODE' | translate }}</span>
         </button>
-        <button (click)="changeView(3)" mat-menu-item>
+        <button (click)="changeView(3)" mat-menu-item *ngIf="!isAssetView">
           <span>{{ 'admissionControl.names.CONTAINER' | translate }}</span>
         </button>
       </mat-menu>

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table-filter/vulnerability-items-table-filter.component.ts
@@ -56,6 +56,13 @@ export class VulnerabilityItemsTableFilterComponent implements OnInit {
   autocompleteTagsOptionActivated = false;
   @ViewChild('namespaceInput') namespaceInput!: ElementRef<HTMLInputElement>;
 
+  get isAssetView(): boolean {
+    return (
+      this.data.viewType === 'infrastructure' ||
+      this.data.viewType === 'registry'
+    );
+  }
+
   options: Options = {
     floor: 0,
     ceil: 10,
@@ -178,6 +185,10 @@ export class VulnerabilityItemsTableFilterComponent implements OnInit {
       matchTypeContainer: new FormControl(filter.matchTypeContainer),
       containerName: new FormControl(filter.containerName),
     });
+
+    if (this.isAssetView) {
+      this.changeView(FilterView.IMAGE);
+    }
   }
 
   submit(): void {

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerability-items/vulnerability-items-table/vulnerability-items-table.component.ts
@@ -372,6 +372,8 @@ export class VulnerabilityItemsTableComponent
           data: {
             filter: this.vulnerabilitiesFilterService.vulQuerySubject$.value,
             domains: this.domains,
+            viewType:
+              this.vulnerabilitiesFilterService.vulQuerySubject$.value.viewType,
           },
           hasBackdrop: false,
           position: { right: '25px', top: '100px' },


### PR DESCRIPTION
## Description

Fix #1226

## Test

1. Navigate to **Security Risks → Vulnerabilities**
2. Switch the Vulnerabilities View to `Infrastructure` or `Registry`
3. Open the Advanced Filter and verify the **Namespaces** filter section is hidden and the entity dropdown only shows Image and Node (Service and Container are hidden)
5. Switch Vulnerabilities View back to `All` or `Containers` and verify Service, Container, and Namespaces filters are restored