### PR TITLE
#1211 Refresh Button in Security Events when Filtered 

### DIFF
--- a/admin/webapp/websrc/app/routes/security-events/security-events.component.ts
+++ b/admin/webapp/websrc/app/routes/security-events/security-events.component.ts
@@ -173,6 +173,7 @@ export class SecurityEventsComponent
     this.securityEventsService.displayedSecurityEvents = [];
     this.printableData = [];
     this.securityEventsService.cachedSecurityEvents = [];
+    this.displayedSecurityEventsJsonBeforeApplyAdvFilter = '[]';
     this.preprocessSecurityEventsData();
   };
 


### PR DESCRIPTION
## Description

Fix #1211

## Test

1. Navigate to **Notifications → Security Events**
2. Apply an Advanced Filter (e.g. Category: Network)
3. Generate a new security event (e.g. ping flood event)
4. Click **Refresh** — verify the new event appears with the filter still active
