### PR TITLE
#1195 Show severity filter in report filter

### DIFF
--- a/admin/src/main/scala/com/neu/model/ContainerConfigJsonProtocol.scala
+++ b/admin/src/main/scala/com/neu/model/ContainerConfigJsonProtocol.scala
@@ -17,7 +17,8 @@ case class ScanReportRequest(
   cursor: Option[Cursor] = None,
   view_pod: Option[String] = None,
   vul_score_filter: Option[VulScoreFilter] = None,
-  filters: Option[Seq[Filter]] = None
+  filters: Option[Seq[Filter]] = None,
+  severity_filter: Option[String] = None
 )
 
 case class Cursor(
@@ -54,7 +55,7 @@ object ContainerConfigJsonProtocol extends DefaultJsonProtocol {
     SnifferParamWarp.apply
   )
   given snifferDataFormat: RootJsonFormat[SnifferData]                               = jsonFormat2(SnifferData.apply)
-  given scanReportRequestFormat: RootJsonFormat[ScanReportRequest]                   = jsonFormat6(
+  given scanReportRequestFormat: RootJsonFormat[ScanReportRequest]                   = jsonFormat7(
     ScanReportRequest.apply
   )
   given cursorFormat: RootJsonFormat[Cursor]                                         = jsonFormat5(Cursor.apply)

--- a/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/assets-scan-report-button.ts
+++ b/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/assets-scan-report-button.ts
@@ -198,6 +198,11 @@ export class AssetsScanReportButton implements OnInit, OnDestroy {
             : filter?.scoreV3?.[1]) ?? 10,
       },
       filters: [],
+      severity_filter:
+        filter?.severityType && filter.severityType !== 'all'
+          ? filter.severityType.charAt(0).toUpperCase() +
+            filter.severityType.slice(1)
+          : '',
     };
 
     const pushFilter = (

--- a/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/partial/advanced-filter/advanced-filter.html
+++ b/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/partial/advanced-filter/advanced-filter.html
@@ -206,6 +206,29 @@
       </ng-container>
     </section>
     <section class="row mx-0 align-items-center mt-3">
+      <span class="d-block col-2">{{ 'profile.TITLE' | translate }}</span>
+      <mat-radio-group
+        aria-label="Severity"
+        class="col row"
+        formControlName="severityType">
+        <mat-radio-button class="col-2" value="all">{{
+          'setting.ALL' | translate
+        }}</mat-radio-button>
+        <mat-radio-button class="col-2" value="critical">{{
+          'enum.CRITICAL' | translate
+        }}</mat-radio-button>
+        <mat-radio-button class="col-2" value="high">{{
+          'enum.HIGH' | translate
+        }}</mat-radio-button>
+        <mat-radio-button class="col-2" value="medium">{{
+          'enum.MEDIUM' | translate
+        }}</mat-radio-button>
+        <mat-radio-button class="col-2" value="low">{{
+          'enum.LOW' | translate
+        }}</mat-radio-button>
+      </mat-radio-group>
+    </section>
+    <section class="row mx-0 align-items-center mt-3">
       <ng-container>
         <mat-slide-toggle
           formControlName="showAccepted"

--- a/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/partial/advanced-filter/advanced-filter.ts
+++ b/admin/webapp/websrc/app/routes/components/ui/assets-scan-report-button/partial/advanced-filter/advanced-filter.ts
@@ -150,6 +150,7 @@ export class AdvancedFilter implements OnInit {
       matchTypeContainer: new FormControl(filter.matchTypeContainer),
       containerName: new FormControl(filter.containerName),
       showAccepted: new FormControl(filter.showAccepted ?? false),
+      severityType: new FormControl(filter.severityType ?? 'all'),
     });
 
     if (!Array.isArray(this.form.controls.selectedDomains.value)) {


### PR DESCRIPTION
## Description

Fix #1195
 
Adds a severity filter radio group (All / Critical / High / Medium / Low) to the Full Report CSV export dialog on the Node and Container pages. The selected severity is passed as `severity_filter` in the scan report request payload to the backend.

## Test

1. Navigate to **Assets → Nodes** or **Assets → Containers**
2. Click **Full Report** CSV button
3. In the filter dialog, select a severity (e.g. **High**)
4. Export the CSV and verify only selected severity value CVEs are present
5. Repeat for Critical, Medium, Low, and All — confirm each filtered CSV contains only the expected severity rows and that all four filtered exports add up to the All export row count
