### PR TITLE
#1205 Disabling setting/dimming modes if Network Security Policy Mode is set to Disabled

### DIFF
--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/config-constants.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/config-constants.ts
@@ -146,7 +146,7 @@ export const NetworkServiceModeField = {
   },
   expressionProperties: {
     'templateOptions.disabled':
-      '!formState.permissions.isNewServiceModeAuthorized',
+      '!formState.permissions.isNewServiceModeAuthorized || !model.net_svc.net_service_status',
     'templateOptions.hint': model =>
       model.net_svc.net_service_status
         ? 'setting.description.ENABLED_NET_POLICY_MODE'


### PR DESCRIPTION
## Description

Fix #1205 

## Test

1. Navigate to **Settings → Configuration**
2. Confirm that **Network Security Policy Mode** radio group (Discover/Monitor/Protect) is disabled when the toggle is off, and enabled when the toggle is on