### PR TITLE
#1207 preserve filter and scroll position during scan refresh

### DIFF
--- a/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registries-table/registries-table.component.ts
@@ -238,11 +238,15 @@ export class RegistriesTableComponent implements OnInit, OnChanges {
 
   onSelectionChanged(params: GridReadyEvent): void {
     if (params.api.getSelectedNodes().length > 0) {
-      console.log(params.api.getSelectedNodes()[0].data);
+      const newSelectedRegistry = params.api.getSelectedNodes()[0].data;
+      const currentSelectedRegistry = this.registriesCommunicationService.selectedRegistry;
+
       this.registriesCommunicationService.setSelectedRegistry(
-        params.api.getSelectedNodes()[0].data
+        newSelectedRegistry
       );
-      this.registriesCommunicationService.detailFilter.setValue('');
+      if(!currentSelectedRegistry || currentSelectedRegistry.name !== newSelectedRegistry.name) {
+        this.registriesCommunicationService.detailFilter.setValue('');
+      }
     }
     this.cd.markForCheck();
   }

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
@@ -115,6 +115,8 @@ export class RegistryDetailsTableComponent implements OnInit, OnChanges {
         sortable: true,
         resizable: true,
       },
+      getRowId: params => params.data.tag ? `${params.data.repository}:${params.data.tag}` : params.data.repository,
+      suppressScrollOnNewData: true,
       rowData: this.rowData,
       columnDefs: this.columnDefs,
       rowSelection: 'single',


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1207

The fix resolves an issue where the registry scan results table would lose its active search filter and reset the scroll position to the top when a scan was started.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

1. navigate to the registry page
2. select a registry from the top table that contains scanned images
3. in the bottom details table, scroll down a bit and enter a value to the filter input
4. click the "Start Scan" button
5. verify: the filter input should retain its value
6. click on a different registry in the top table
7. verify: the filter input should be cleared for the new registry context

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
<img width="932" height="838" alt="Screenshot 2026-06-05 at 8 22 18 PM" src="https://github.com/user-attachments/assets/5e95c23d-bfb8-426c-9dde-2c653acf0e91" />
