### PR TITLE
#1190: [Bug] hide global permissions from show advance setting's table

### DIFF
--- a/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.html
@@ -123,6 +123,7 @@
       [domains]="data.domains"
       [global_role]="selectedRole"
       [group_roles]="data.domainRoles"
+      [rolesNotForDomain]="data.rolesNotForDomain"
       [hidden]="
         !showAdvSetting ||
         (data.isEdit &&

--- a/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
+++ b/admin/webapp/websrc/app/routes/components/users-grid/add-edit-user-dialog/add-edit-user-dialog.component.ts
@@ -240,12 +240,14 @@ export class AddEditUserDialogComponent implements OnInit {
   @Output() confirm = new EventEmitter();
   submit(): void {
     this.saving$.next(true);
-    const role_domains = this.domainTableSource.data
-      .filter(({ namespaces }) => namespaces.length)
-      .reduce((acc, role) => {
-        const { namespaceRole, namespaces } = role;
-        return { ...acc, [namespaceRole]: [...namespaces] };
-      }, {});
+    const role_domains = this.isRoleWithoutDomainScope
+      ? {}
+      : this.domainTableSource.data
+          .filter(({ namespaces }) => namespaces.length)
+          .reduce((acc, role) => {
+            const { namespaceRole, namespaces } = role;
+            return { ...acc, [namespaceRole]: [...namespaces] };
+          }, {});
     if (this.data.isEdit) {
       this.confirm.emit({
         ...this.data.user,

--- a/admin/webapp/websrc/app/routes/settings/common/group-domain-role/group-domain-role-table/group-domain-role-table.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/common/group-domain-role/group-domain-role-table/group-domain-role-table.component.ts
@@ -37,6 +37,7 @@ export class GroupDomainRoleTableComponent
   @Input() global_role!: string;
   @Input() group_roles!: string[];
   @Input() isReadOnly: boolean = false;
+  @Input() rolesNotForDomain: string[] = [];
   displayedColumns = ['namespaceRoles', 'namespaces'];
   separatorKeysCodes: number[] = [ENTER, COMMA];
   namespaceCtrl = new FormControl();
@@ -148,19 +149,18 @@ export class GroupDomainRoleTableComponent
   }
 
   updateTable(): void {
-    if (this.global_role === 'admin') {
-      this.dataSource.data = this.dataSource.data.filter(
-        ({ namespaceRole }) => namespaceRole !== 'admin'
-      );
-      this.dataSource.data[0].namespaces = [];
-      this.domainChips = [];
-      return;
-    }
     this.dataSource.data = this.dataSource.data.filter(
-      ({ namespaceRole }) => namespaceRole !== this.global_role
+      ({ namespaceRole }) =>
+        namespaceRole !== this.global_role &&
+        !this.rolesNotForDomain.includes(namespaceRole)
     );
     this.group_roles.forEach((role: string) => {
-      if (role && !this.findRowFromRole(role) && role !== this.global_role) {
+      if (
+        role &&
+        !this.findRowFromRole(role) &&
+        role !== this.global_role &&
+        !this.rolesNotForDomain.includes(role)
+      ) {
         this.dataSource.data = [
           ...this.dataSource.data,
           { namespaceRole: role, namespaces: [] },


### PR DESCRIPTION
## Description

Fix #1190
Adds logic to exclude roles_not_for_domain rows from Advanced Settings table in addition to hiding Advanced Settings when global role is contained in roles_not_for_domain.


## Test

1. Go to **Settings > Users&Roles** page, on the Roles tab, add a role(role1) that contains only permissions "Authentication", "CI Scan" or "Admission Control".
2. Go to **Settings > Users&Roles** page, on the Users tab, click add user button
3. Select **none** in the global role drop-down
4. Observe the Namespace Roles columns in the advanced setting section that role1 is NOT shown