### PR TITLE
#1243 The DLP configuration popup cannot be close by the close button in the Groups page

### DIFF
--- a/admin/webapp/websrc/app/routes/components/apikeys-grid/add-apikey-dialog/add-apikey-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/components/apikeys-grid/add-apikey-dialog/add-apikey-dialog.component.html
@@ -174,7 +174,7 @@
         class="me-3 mb-3 apikey__icon"
         >key
       </mat-icon>
-      <mat-form-field class="w-75" appearance="outline">
+      <mat-form-field class="w-75">
         <mat-label>{{ 'apikey.gridHeader.NAME' | translate }}</mat-label>
         <input
           matInput
@@ -184,11 +184,13 @@
         <button
           matSuffix
           [cdkCopyToClipboard]="apikeyInit.apikey_name"
-          class="d-flex justify-content-center align-items-center"
+          class="d-flex justify-content-center align-items-center copy-btn"
           mat-stroked-button
           type="button">
-          <i class="eos-icons">content_copy</i>
-          {{ 'apikey.addApikey.COPY' | translate }}
+          <div class="d-flex justify-content-center align-items-center">
+            <i class="eos-icons">content_copy</i>
+            {{ 'apikey.addApikey.COPY' | translate }}
+          </div>
         </button>
       </mat-form-field>
     </div>
@@ -199,7 +201,7 @@
         class="me-3 mb-3 apikey__icon"
         >key
       </mat-icon>
-      <mat-form-field class="w-75" appearance="outline">
+      <mat-form-field class="w-75">
         <mat-label>{{ 'apikey.addApikey.SECRET' | translate }}</mat-label>
         <input
           matInput
@@ -209,11 +211,13 @@
         <button
           matSuffix
           [cdkCopyToClipboard]="apikeyInit.apikey_secret"
-          class="d-flex justify-content-center align-items-center"
+          class="d-flex justify-content-center align-items-center copy-btn"
           mat-stroked-button
           type="button">
-          <i class="eos-icons">content_copy</i>
-          {{ 'apikey.addApikey.COPY' | translate }}
+          <div class="d-flex justify-content-center align-items-center">
+            <i class="eos-icons">content_copy</i>
+            {{ 'apikey.addApikey.COPY' | translate }}
+          </div>
         </button>
       </mat-form-field>
     </div>
@@ -230,7 +234,7 @@
         class="me-3 mb-3 apikey__icon"
         >key
       </mat-icon>
-      <mat-form-field class="w-75" appearance="outline">
+      <mat-form-field class="w-75">
         <mat-label>{{ 'apikey.addApikey.TOKEN' | translate }}</mat-label>
         <input
           matInput
@@ -240,11 +244,12 @@
         <button
           matSuffix
           [cdkCopyToClipboard]="bearerToken"
-          class="d-flex justify-content-center align-items-center"
           mat-stroked-button
           type="button">
-          <i class="eos-icons">content_copy</i>
-          {{ 'apikey.addApikey.COPY' | translate }}
+          <div class="d-flex justify-content-center align-items-center">
+            <i class="eos-icons">content_copy</i>
+            {{ 'apikey.addApikey.COPY' | translate }}
+          </div>
         </button>
       </mat-form-field>
     </div>

--- a/admin/webapp/websrc/app/routes/components/apikeys-grid/add-apikey-dialog/add-apikey-dialog.component.scss
+++ b/admin/webapp/websrc/app/routes/components/apikeys-grid/add-apikey-dialog/add-apikey-dialog.component.scss
@@ -46,3 +46,11 @@
 .w-15 {
   width: 15% !important; 
 }
+
+.mat-mdc-form-field-input-control.mat-mdc-form-field-input-control {
+  padding: 0 10px;
+}
+
+.type-label {
+  height: 26px;
+}

--- a/admin/webapp/websrc/app/routes/components/file-access-rules/partial/add-edit-file-access-rule-modal/add-edit-file-access-rule-modal.component.html
+++ b/admin/webapp/websrc/app/routes/components/file-access-rules/partial/add-edit-file-access-rule-modal/add-edit-file-access-rule-modal.component.html
@@ -6,8 +6,8 @@
       }}
     </h4>
     <div class="d-flex align-items-center justify-content-center mb-1">
-      <button mat-icon-button aria-label="close">
-        <i class="eos-icons" (click)="onCancel()">close</i>
+      <button mat-icon-button aria-label="close" (click)="onCancel()">
+        <i class="eos-icons">close</i>
       </button>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/components/group-details/partial/group-dlp-config-modal/group-dlp-config-modal.component.html
+++ b/admin/webapp/websrc/app/routes/components/group-details/partial/group-dlp-config-modal/group-dlp-config-modal.component.html
@@ -22,8 +22,8 @@
       </mat-slide-toggle>
     </section>
     <div class="ms-auto align-items-center mb-1">
-      <button mat-icon-button aria-label="close">
-        <i class="eos-icons" (click)="onCancel()">close</i>
+      <button mat-icon-button aria-label="close" (click)="onCancel()">
+        <i class="eos-icons">close</i>
       </button>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/components/group-details/partial/group-waf-config-modal/group-waf-config-modal.component.html
+++ b/admin/webapp/websrc/app/routes/components/group-details/partial/group-waf-config-modal/group-waf-config-modal.component.html
@@ -22,8 +22,8 @@
       </mat-slide-toggle>
     </section>
     <div class="ms-auto align-items-center mb-1">
-      <button mat-icon-button aria-label="close">
-        <i class="eos-icons" (click)="onCancel()">close</i>
+      <button mat-icon-button aria-label="close" (click)="onCancel()">
+        <i class="eos-icons">close</i>
       </button>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/components/process-profile-rules/partial/add-edit-process-profile-rule-modal/add-edit-process-profile-rule-modal.component.html
+++ b/admin/webapp/websrc/app/routes/components/process-profile-rules/partial/add-edit-process-profile-rule-modal/add-edit-process-profile-rule-modal.component.html
@@ -6,8 +6,8 @@
       }}
     </h4>
     <div class="d-flex align-items-center justify-content-center mb-1">
-      <button mat-icon-button aria-label="close">
-        <i class="eos-icons" (click)="onCancel()">close</i>
+      <button mat-icon-button aria-label="close" (click)="onCancel()">
+        <i class="eos-icons">close</i>
       </button>
     </div>
   </div>

--- a/admin/webapp/websrc/app/routes/vulnerability-profile/vulnerability-profile-table/vulnerability-profile-table-import-dialog/vulnerability-profile-table-import-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/vulnerability-profile/vulnerability-profile-table/vulnerability-profile-table-import-dialog/vulnerability-profile-table-import-dialog.component.html
@@ -1,8 +1,12 @@
 <div class="nv-dialog">
   <div class="d-flex justify-content-between align-items-center">
     <h4 mat-dialog-title class="mb-2">{{ 'setting.IMPORT' | translate }}</h4>
-    <button class="mb-2" aria-label="Close dialog" mat-icon-button>
-      <i class="eos-icons" (click)="onCancel()">close</i>
+    <button
+      class="mb-2"
+      aria-label="Close dialog"
+      (click)="onCancel()"
+      mat-icon-button>
+      <i class="eos-icons">close</i>
     </button>
   </div>
   <hr class="fancy mb-2" />


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1243

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, open the popup of following pages
1. Add rule popup in file access rule panel in Groups page
2. Add rule popup in profile process rule panel in Groups page
3. Configure DLP popup in DLP panel in Groups page
4. Configure WAF popup in WAF panel in Groups page
5. Import popup in Vulnerability profile page

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
