### PR TITLE
revert dependency setuptools to 80.10.2 (release/v5.6)

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -5,4 +5,4 @@ requests==2.33.0
 six==1.11.0
 supervisor==4.2.5
 urllib3==2.7.0
-setuptools==83.0.0
+setuptools==80.10.2


### PR DESCRIPTION
## Description

revert dependency `setuptools` to `80.10.2` for now
