### PR TITLE
update supervisor to 4.3.0

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -3,6 +3,6 @@ cmd2==2.3.3
 prettytable==2.5.0
 requests==2.33.0
 six==1.11.0
-supervisor==4.2.5
+supervisor==4.3.0
 urllib3==2.7.0
 setuptools==83.0.0


### PR DESCRIPTION
## Description

Update `supervisor` to `4.3.0` so that `setuptools 83.0.0` does not cause problem.

Command in manager pod to verify:
`supervisord -v`
