### PR TITLE
#1246 [bug] When image name is long, cant close the registry scan window

### DIFF
--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-details-dialog.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-details-dialog.component.html
@@ -1,13 +1,17 @@
 <ng-container
   *ngIf="imageAndLayers$ | async as imageAndLayers; else loadingTemplate">
   <div class="dialog-header d-flex justify-content-between align-items-center">
-    <h2 class="mb-0 h4 font-weight-bold">
+    <h2 class="mb-0 h4 font-weight-bold text-truncate me-3"
+        style="max-width: calc(100% - 50px);"
+        [matTooltip]="registryTitle"
+        matTooltipPosition="below">
       {{ registryTitle }}
     </h2>
     <button
       aria-label="Close dialog button"
       id="registry-details-dialog-close-button"
       (click)="onNoClick()"
+      class="flex-shrink-0"
       mat-icon-button>
       <i class="eos-icons">close</i>
     </button>

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-details-dialog.component.scss
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-dialog/registry-details-dialog.component.scss
@@ -15,5 +15,8 @@
   margin: -24px -24px 30px -24px;
   background-color: #f8f8f8;
   border: #babfc7 1px solid;
+
+  overflow: hidden;
+  white-space: nowrap;
 }
 


### PR DESCRIPTION
## Description

This PR resolves a UI overflow issue in the Registry Scan Details dialog where a long image name or repo URL causes the header text to expand beyond its container limits. As a result, the dialog close button was pushed off-screen, making the modal impossible to close.

Fix #1246 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:
1. Navigate to Assets -> Registries.  
2. Click + Add to register or edit a Docker registry.  
3. Set the repository filter to a very long image path/tag combination

e.g. 
nvlab/alpine23456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678:12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678

4. Initiate a scan to render in the details grid
5. Click the image row to open the Registry Details popup dialog
6. Expected Result: The header title gets truncates with an ellipsis and the close button remains visible, and hovering over the title reveals the full title content in a tooltip.
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

<img width="1741" height="788" alt="Screenshot 2026-07-22 at 11 10 04 AM" src="https://github.com/user-attachments/assets/e7980c85-d3b8-4b75-8290-ade5f91d05f4" />
