### PR TITLE
#1266 NV UI change for calling some backend REST APIs because of field name change

### DIFF
--- a/admin/src/main/scala/com/neu/api/risk/RiskApi.scala
+++ b/admin/src/main/scala/com/neu/api/risk/RiskApi.scala
@@ -100,12 +100,12 @@ class RiskApi(resourceService: RiskService) extends BaseApi {
             pathPrefix("assets-view") {
               pathEnd {
                 patch {
-                  parameter(Symbol("queryToken").?) { queryToken =>
+                  parameter(Symbol("queryId").?) { queryId =>
                     entity(as[VulnerabilityAssetQuery]) { assetQuery =>
                       Utils.respondWithWebServerHeaders() {
                         resourceService.queryCveAssetsView(
                           tokenId,
-                          queryToken,
+                          queryId,
                           assetQuery
                         )
                       }

--- a/admin/src/main/scala/com/neu/service/risk/RiskService.scala
+++ b/admin/src/main/scala/com/neu/service/risk/RiskService.scala
@@ -133,13 +133,13 @@ class RiskService extends BaseService with DefaultJsonFormats with LazyLogging {
 
   def queryCveAssetsView(
     tokenId: String,
-    queryToken: Option[String],
+    queryId: Option[String],
     query: VulnerabilityAssetQuery
   ): Route = {
-    val url = queryToken.fold(
+    val url = queryId.fold(
       s"${baseClusterUri(tokenId)}/assetvul"
-    ) { queryToken =>
-      s"${baseClusterUri(tokenId)}/assetvul?token=$queryToken"
+    ) { queryId =>
+      s"${baseClusterUri(tokenId)}/assetvul?token=$queryId"
     }
     complete {
       RestClient.httpRequestWithHeader(

--- a/admin/webapp/websrc/app/common/api/risks-http.service.ts
+++ b/admin/webapp/websrc/app/common/api/risks-http.service.ts
@@ -145,14 +145,14 @@ export class RisksHttpService {
     );
   }
 
-  postAssetsViewData(queryToken: string, lastModifiedTime: number, includeNoVulAssets: boolean = false) {
+  postAssetsViewData(queryId: string, lastModifiedTime: number, includeNoVulAssets: boolean = false) {
     return GlobalVariable.http.patch<any>(
       PathConstant.ASSETS_VULS_URL,
       {
         last_modified_timestamp: lastModifiedTime,
         include_no_vul_assets: includeNoVulAssets
       },
-      { params: { queryToken: queryToken } }
+      { params: { queryId: queryId } }
     );
   }
 

--- a/admin/webapp/websrc/app/common/services/registries.service.ts
+++ b/admin/webapp/websrc/app/common/services/registries.service.ts
@@ -214,7 +214,7 @@ export class RegistriesService {
       .pipe(
         map(res => {
           return {
-            queryToken: res.query_token,
+            queryId: res.query_id,
             summary: res.summary,
             totalRecords: res.total_records,
           };

--- a/admin/webapp/websrc/app/common/types/vulnerabilities/vulnerabilities.ts
+++ b/admin/webapp/websrc/app/common/types/vulnerabilities/vulnerabilities.ts
@@ -87,7 +87,7 @@ export interface VulnerabilitiesQuerySessionData {
 }
 
 export interface VulnerabilitiesQueryData {
-  query_token: string;
+  query_id: string;
   status: string;
   summary: VulnerabilitiesQuerySummary;
   total_matched_records: number;

--- a/admin/webapp/websrc/app/routes/components/container-detail/container-detail.component.ts
+++ b/admin/webapp/websrc/app/routes/components/container-detail/container-detail.component.ts
@@ -37,7 +37,7 @@ export class ContainerDetailComponent {
   redirectToRegistry(imageId: string) {
     this.registriesService.getAllScannedImagesSummary().subscribe(data => {
       this.registriesService
-        .getAllScannedImages(data.queryToken, 0, 1, [], {
+        .getAllScannedImages(data.queryId, 0, 1, [], {
           '-': {
             filter: imageId,
           },

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table-all-view.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table-all-view.component.ts
@@ -46,7 +46,7 @@ export class RegistryDetailsTableAllViewComponent
 {
   @Input() gridHeight!: number;
   @Input() selectedRegistry!: Summary;
-  @Input() queryToken!: string;
+  @Input() queryId!: string;
   @Input() totalCount!: number;
   @Input() filter!: FormControl;
   @Input() linkedImage: string;
@@ -151,7 +151,7 @@ export class RegistryDetailsTableAllViewComponent
   ) {}
 
   ngOnInit(): void {
-    console.log('On all images view', this.queryToken);
+    console.log('On all images view', this.queryId);
     this.gridOptions = {
       defaultColDef: {
         resizable: true,
@@ -192,7 +192,7 @@ export class RegistryDetailsTableAllViewComponent
   getData(params: IGetRowsParams) {
     return this.registriesService
       .getAllScannedImages(
-        this.queryToken,
+        this.queryId,
         params.startRow,
         300,
         params.sortModel,

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details.component.html
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details.component.html
@@ -104,7 +104,7 @@
         <app-registry-details-table-all-view
           *ngIf="registryDetails.isAllView"
           [filter]="filter"
-          [queryToken]="registryDetails.allScannedImagesSummary!.queryToken"
+          [queryId]="registryDetails.allScannedImagesSummary!.queryId"
           [totalCount]="registryDetails.allScannedImagesSummary!.totalRecords"
           [gridHeight]="gridHeight"
           [linkedImage]="linkedImage"

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details.component.ts
@@ -23,11 +23,11 @@ export class RegistryDetailsComponent {
   @Input() linkedImage: string;
   @Input() linkedTag: string;
   filter = new FormControl('');
-  queryToken: string;
+  queryId: string;
   registryDetails$ = this.registriesCommunicationService.registryDetails$.pipe(
     tap(res => {
       if (!!res.isAllView)
-        this.queryToken = res.allScannedImagesSummary!.queryToken;
+        this.queryId = res.allScannedImagesSummary!.queryId;
     }),
     catchError(err => {
       this.error = err;
@@ -70,7 +70,7 @@ export class RegistryDetailsComponent {
 
   exportAllScannedImagesCSV(): void {
     this.registriesService
-      .getAllScannedImages(this.queryToken, 0, -1, [], {
+      .getAllScannedImages(this.queryId, 0, -1, [], {
         '-': { filter: this.filter.value },
       })
       .subscribe(res => {

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.component.ts
@@ -213,7 +213,7 @@ export class VulnerabilitiesComponent implements OnDestroy {
   };
 
   private getVulnerabilitiesViewReportData = (
-    queryToken: string,
+    queryId: string,
     cb: Function,
     dialogRef,
     options
@@ -233,7 +233,7 @@ export class VulnerabilitiesComponent implements OnDestroy {
   };
 
   private getAssetsViewReportData = (
-    queryToken: string,
+    queryId: string,
     cb: Function,
     dialogRef,
     options
@@ -241,7 +241,7 @@ export class VulnerabilitiesComponent implements OnDestroy {
     this.withoutAppendix = options.withoutAppendix;
     this.vulnerabilitiesService
       .getAssetsViewReportData(
-        queryToken,
+        queryId,
         options.lastModifiedTime,
         options.includeNoVulAssets)
       .subscribe(

--- a/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.service.ts
+++ b/admin/webapp/websrc/app/routes/vulnerabilities/vulnerabilities.service.ts
@@ -37,7 +37,7 @@ export class VulnerabilitiesService {
             )
           ) {
             let emptyQuery: VulnerabilitiesQueryData = {
-              query_token: '',
+              query_id: '',
               total_matched_records: 0,
               total_records: 0,
               status: '',
@@ -64,7 +64,7 @@ export class VulnerabilitiesService {
       )
     ),
     tap(queryData => {
-      this.activeToken = queryData.query_token;
+      this.activeToken = queryData.query_id;
       this.activeSummary = queryData.summary;
       this.status = queryData.status;
       this.activeSummarySubject$.next();
@@ -282,12 +282,12 @@ export class VulnerabilitiesService {
   }
 
   getAssetsViewReportData(
-    queryToken: string,
+    queryId: string,
     lastModifiedTime: number,
     includeNoVulAssets: boolean = false
   ): Observable<any> {
     return this.risksHttpService
-      .postAssetsViewData(queryToken, lastModifiedTime, includeNoVulAssets);
+      .postAssetsViewData(queryId, lastModifiedTime, includeNoVulAssets);
   }
 
   getDomain(): Observable<string[]> {


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1266

Renamed all the `queryToken`, `query-token` into `queryId`, `query-id`

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Go to Risk > Vulnerabilities page to monitor the API request. The pagination request should work as usual when it accept queryID and use it in the payload for page display and reports export

Config harbor registry in the backend
Go to Assets > Registries page, to monitor the `view all images` table and its API calls. Everything should work as usual with the queryID in the payload

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
