### PR TITLE
Fix null value shown in dashboard risk panel

### DIFF
--- a/admin/webapp/websrc/app/routes/components/security-risk-panel/security-risk-panel.component.ts
+++ b/admin/webapp/websrc/app/routes/components/security-risk-panel/security-risk-panel.component.ts
@@ -110,12 +110,14 @@ export class SecurityRiskPanelComponent implements OnInit {
       ],
       factorComment: [
         `${this.translate.instant('dashboard.heading.CVE_DB_VERSION')}: ${
-          summaryInfo.cvedb_version
+          summaryInfo.cvedb_version || '-'
         }`,
-        `(${this.datePipe.transform(
-          summaryInfo.cvedb_create_time,
-          'MMM dd, y'
-        )})`,
+        summaryInfo.cvedb_create_time
+          ? `(${this.datePipe.transform(
+              summaryInfo.cvedb_create_time,
+              'MMM dd, y'
+            )})`
+          : '',
       ],
       subScore: {
         height: `${95 - scoreInfo.security_scores.vulnerability_score_by_100}%`,


### PR DESCRIPTION
## Description

Fix #1245
Adds null guards around `cvedb_version` and `cvedb_create_time`

## Test

1. Deploy a fresh fleet and manager build (before any CVE DB scan has populated `cvedb_version`/`cvedb_create_time`).
2. Navigate to the Dashboard page.
3. Confirm the **Vulnerability Exploit Risk Score** panel no longer shows `(null)`.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
