### PR TITLE
#1263 Feature Request: Web UI: Once CA is added, TLS CA file should not be editable; #1282 HTTP chunk size exceeds the configured limit of 31457280 bytes when exporting Vulnerabilities

### DIFF
--- a/admin/webapp/websrc/app/common/neuvector-formly/edit-table-controls/edit-table-controls.component.html
+++ b/admin/webapp/websrc/app/common/neuvector-formly/edit-table-controls/edit-table-controls.component.html
@@ -8,7 +8,11 @@
   </ng-container>
   <ng-template #otherButtons>
     <ng-container *ngIf="isEditable.value">
-      <button type="button" mat-button (click)="submit()">
+      <button
+        type="button"
+        mat-button
+        (click)="submit()"
+        [disabled]="!form.valid">
         {{ 'cveProfile.ACCEPT' | translate }}
       </button>
       <button type="button" mat-button (click)="cancel()">
@@ -17,10 +21,10 @@
     </ng-container>
     <ng-container *ngIf="!isEditable.value">
       <button type="button" mat-button (click)="edit()">
-        {{ 'cveProfile.EDIT' | translate }}
+        <em class="eos-icons">edit</em>
       </button>
       <button type="button" mat-button (click)="delete()">
-        {{ 'cveProfile.REMOVE' | translate }}
+        <em class="eos-icons">delete</em>
       </button>
     </ng-container>
   </ng-template>

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/tls-constants.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form-config/constants/tls-constants.ts
@@ -97,7 +97,7 @@ export const TlsTableField: FormlyFieldConfig = {
           rows: 15,
           readOnly: {
             type: 'text',
-            template: field => `${field.model[field.key] || ''}`,
+            template: () => '',
           },
         },
         validators: {
@@ -110,7 +110,7 @@ export const TlsTableField: FormlyFieldConfig = {
         defaultValue: true,
         templateOptions: {
           flexWidth: '10%',
-          showDeleteButtonOnly: true,
+          showDeleteButtonOnly: false,
           fieldClass: 'justify-content-center',
         },
         expressionProperties: {

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.html
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.html
@@ -12,7 +12,7 @@
       *appDisplayControl="'write_config'"
       [appearance]="'mat-raised-button'"
       [color]="'primary'"
-      [disabled]="!configForm.valid || !configForm.dirty || submittingForm"
+      [disabled]="hasPendingCertificateEdit || !configForm.valid || (!configForm.dirty && !hasWebhookValueChanged) || submittingForm"
       [loading]="submittingForm"
       [text]="'setting.SUBMIT' | translate"
       [type]="'submit'">

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
@@ -17,7 +17,7 @@ import { FormlyFormOptions } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 import { NotificationService } from '@services/notification.service';
 import { SettingsService } from '@services/settings.service';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import { finalize } from 'rxjs/operators';
 import { ConfigFormConfig } from './config-form-config';
 import { OtherWebhookType } from './config-form-config/constants';
@@ -36,6 +36,9 @@ export class ConfigFormComponent implements OnInit {
 
   ibmSetup!: IBMSetupGetResponse;
   submittingForm = false;
+  hasPendingCertificateEdit = true;
+  hasWebhookValueChanged = false;
+  private originalWebhooks: any[] = [];
   configForm = new FormGroup({});
   configFields = cloneDeep(ConfigFormConfig);
   configOptions: FormlyFormOptions = {
@@ -74,6 +77,35 @@ export class ConfigFormComponent implements OnInit {
     return this._config;
   }
 
+  private updatePendingCertificateEdit(): void {
+    const formValue = this.configForm?.getRawValue() as any;
+    const certs =
+      formValue?.tls?.cacerts ?? this._config?.tls?.cacerts ?? [];
+    this.hasPendingCertificateEdit =
+      Array.isArray(certs) && certs.some(c => c?.isEditable === true);
+  }
+
+  private updateWebhookValueChanges(): void {
+    const formValue = this.configForm?.getRawValue() as any;
+    const currentWebhooks = cloneDeep(formValue?.webhooks ?? []);
+
+    if (!Array.isArray(currentWebhooks) || !Array.isArray(this.originalWebhooks)) {
+      this.hasWebhookValueChanged = false;
+      return;
+    }
+
+    const normalize = (items: any[] = []) =>
+      items.map(({ isEditable, ...webhook }) => ({
+        ...webhook,
+        type: webhook.type === OtherWebhookType ? '' : webhook.type,
+      }));
+
+    this.hasWebhookValueChanged = !isEqual(
+      normalize(currentWebhooks),
+      normalize(this.originalWebhooks)
+    );
+  }
+
   @Input() set config(val) {
     this._config = val;
     if (this._config.proxy.registry_http_proxy.url) {
@@ -96,6 +128,9 @@ export class ConfigFormComponent implements OnInit {
       e.type = e.type || OtherWebhookType;
     });
     this._config.ibmsa.ibmsa_ep_dashboard_url ||= this.dashboardUrl;
+    this.originalWebhooks = cloneDeep(this._config?.webhooks ?? []);
+    this.updatePendingCertificateEdit();
+    this.updateWebhookValueChanges();
   }
 
   constructor(
@@ -127,6 +162,12 @@ export class ConfigFormComponent implements OnInit {
       isNsUserExportNetworkRuleAuthorized: isSettingAuth,
     };
     this.serverErrorMessage = '';
+    this.configForm.valueChanges.subscribe(() => {
+      this.updatePendingCertificateEdit();
+      this.updateWebhookValueChanges();
+    });
+    this.updatePendingCertificateEdit();
+    this.updateWebhookValueChanges();
     this.cd.detectChanges();
 
     // reset the status of the sliders to fix the issue NVSHAS-8599
@@ -159,6 +200,14 @@ export class ConfigFormComponent implements OnInit {
               this._config.misc.cluster_name;
             this.multiClusterService.dispatchClusterNameChangeEvent();
           }
+
+          this.originalWebhooks = cloneDeep(
+            (this.configForm.getRawValue() as any)?.webhooks ??
+              this._config?.webhooks ??
+              []
+          );
+          this.updateWebhookValueChanges();
+
           this.notificationService.open(this.tr.instant('setting.SUBMIT_OK'));
           this.configOptions.resetModel?.(this._config);
           setTimeout(() => this.configOptions.resetModel?.(this._config));

--- a/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/config-form/config-form.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   Inject,
   Input,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
@@ -19,6 +20,7 @@ import { NotificationService } from '@services/notification.service';
 import { SettingsService } from '@services/settings.service';
 import { cloneDeep, isEqual } from 'lodash';
 import { finalize } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 import { ConfigFormConfig } from './config-form-config';
 import { OtherWebhookType } from './config-form-config/constants';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -31,8 +33,9 @@ import { MultiClusterService } from '@services/multi-cluster.service';
   templateUrl: './config-form.component.html',
   styleUrls: ['./config-form.component.scss'],
 })
-export class ConfigFormComponent implements OnInit {
+export class ConfigFormComponent implements OnInit, OnDestroy {
   private _config!: ConfigV2Vo;
+  private valueChangesSub?: Subscription;
 
   ibmSetup!: IBMSetupGetResponse;
   submittingForm = false;
@@ -162,7 +165,7 @@ export class ConfigFormComponent implements OnInit {
       isNsUserExportNetworkRuleAuthorized: isSettingAuth,
     };
     this.serverErrorMessage = '';
-    this.configForm.valueChanges.subscribe(() => {
+    this.valueChangesSub = this.configForm.valueChanges.subscribe(() => {
       this.updatePendingCertificateEdit();
       this.updateWebhookValueChanges();
     });
@@ -174,6 +177,10 @@ export class ConfigFormComponent implements OnInit {
     setTimeout(() => {
       this.configForm.markAsPristine();
     }, 300);
+  }
+
+  ngOnDestroy(): void {
+    this.valueChangesSub?.unsubscribe();
   }
 
   submitForm(): void {

--- a/admin/webapp/websrc/app/routes/settings/configuration/configuration.component.ts
+++ b/admin/webapp/websrc/app/routes/settings/configuration/configuration.component.ts
@@ -83,6 +83,7 @@ export class ConfigurationComponent
             cacerts: value.tls_cfg?.cacerts?.map((c, i) => ({
               id: i,
               context: c,
+              isEditable: false,
             })),
           },
         };

--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -74,7 +74,7 @@ ssl.pekko.http {
     server-header = ""
     parsing {
       max-content-length = 50m
-      max-chunk-size = 30m
+      max-chunk-size = 100m
       incoming-auto-chunking-threshold-size = infinite
       header-cache {
         default = 0
@@ -97,7 +97,7 @@ noneSsl.pekko.http {
     max-encryption-chunk-size = 10m
     parsing {
       max-content-length = 50m
-      max-chunk-size = 30m
+      max-chunk-size = 100m
       incoming-auto-chunking-threshold-size = infinite
       header-cache {
         default = 0
@@ -109,14 +109,14 @@ noneSsl.pekko.http {
 
 pekko.http {
   client {
-    response-chunk-aggregation-limit = 30m
+    response-chunk-aggregation-limit = 100m
     max-encryption-chunk-size = 10m
     idle-timeout = 180s
     request-timeout = 120s
     connecting-timeout = 100s
     parsing {
       max-content-length = 50m
-      max-chunk-size = 30m
+      max-chunk-size = 100m
       incoming-auto-chunking-threshold-size = infinite
     }
   }


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #1263 

https://github.com/user-attachments/assets/0bc220fb-920e-4fde-8e36-ee0b2aa951f8

Fix #1282 

Enlarge the max chunk size for ehcache

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

For #1263 
1. Go to Settings > Configurations page
2. Test TLS Self-Signed Certification Configuration section, and add a certificate and accept the change, then submit the whole configuration form
3. On the existing record, observe the certificate field, there should not be any content visible util clicking edit button, then the certificate content is visible.
4. Go to Webhooks section to test the regression case. It should be the same as original behavior
5. There is a fix for the existing bug when removing a webhook record. When the record is removed, the submit button of the configuration form is not enabled.

For #1282 

Regression test for any API call.
Prepare a large scale data in for vulnerabilities page or any other APIs which can return large data, like containers, groups. To test if if the limit is change into 100MB for the response.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
