### PR TITLE
fixed #1272 "Vulnerabilities" column always shows wrong number

### DIFF
--- a/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
+++ b/admin/webapp/websrc/app/routes/registries/regestries-communication.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import { RepoGetResponse, Summary } from '@common/types';
 import {
   filter,
@@ -15,6 +15,7 @@ import { FormControl } from '@angular/forms';
 export interface RegistryDetails {
   selectedRegistry: Summary;
   isAllView: boolean;
+  isFedRepo?: boolean;
   repositories?: RepoGetResponse;
   allScannedImagesSummary?: any;
 }
@@ -30,17 +31,20 @@ export class RegistriesCommunicationService {
   detailFilter: FormControl;
   selectedRegistry$: Observable<Summary | undefined> =
     this.selectedRegistrySubject$.asObservable();
+
   private refreshingDetailsSubject$ = new BehaviorSubject<boolean>(false);
   refreshingDetails$ = this.refreshingDetailsSubject$.asObservable();
-  registryDetails$ = this.selectedRegistry$
+
+  registryDetails$ = combineLatest([
+    this.selectedRegistry$.pipe(filter(summary => summary !== undefined)),
+    this.refreshDetailsSubject$.pipe(startWith(null)),
+  ])
     .pipe(
-      filter(summary => summary !== undefined),
-      // distinctUntilChanged(),
-      switchMap(summary => {
+      switchMap(([summary]) => {
         if (!!summary!.isAllView) {
           return this.registriesService.getAllScannedImagesSummary().pipe(
             map(allScannedImagesSummary => ({
-              selectedRegistry: summary,
+              selectedRegistry: summary!,
               isAllView: true,
               isFedRepo: false,
               allScannedImagesSummary,
@@ -56,7 +60,7 @@ export class RegistriesCommunicationService {
             .getFederatedRepoScanRegistrySummary(summary!.name)
             .pipe(
               map(repositories => ({
-                selectedRegistry: summary,
+                selectedRegistry: summary!,
                 isAllView: false,
                 isFedRepo: true,
                 repositories,
@@ -70,7 +74,7 @@ export class RegistriesCommunicationService {
         } else {
           return this.registriesService.getRepo(summary!.name).pipe(
             map(repositories => ({
-              selectedRegistry: summary,
+              selectedRegistry: summary!,
               isAllView: false,
               repositories,
             })),
@@ -82,8 +86,8 @@ export class RegistriesCommunicationService {
           );
         }
       })
-    )
-    .pipe() as Observable<RegistryDetails>;
+    ) as Observable<RegistryDetails>;
+
   private startingScanSubject$ = new BehaviorSubject<boolean>(false);
   startingScan$ = this.startingScanSubject$.asObservable();
   private stoppingScanSubject$ = new BehaviorSubject<boolean>(false);

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-os-cell/registry-details-os-cell.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-os-cell/registry-details-os-cell.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 import { TranslateModule } from '@ngx-translate/core';
@@ -15,28 +15,35 @@ import { GlobalConstant } from 'app/common/constants/global.constant';
 })
 export class RegistryDetailsOsCell implements ICellRendererAngularComp {
   private params!: ICellRendererParams;
-  os!: string;
-  os_scan_status!: string;
+  os: string = '';
+  os_scan_status: string = '';
   OS_STATUS = GlobalConstant.OS_STATUS;
 
+  constructor(private cd: ChangeDetectorRef) {}
+
   agInit(params: ICellRendererParams): void {
+    this.updateValues(params);
+  }
+
+  refresh(params: ICellRendererParams): boolean {
+    this.updateValues(params);
+    this.cd.markForCheck();
+    return true;
+  }
+
+  private updateValues(params: ICellRendererParams): void {
     this.params = params;
     this.os =
-      params && params.node.data
+      params && params.node?.data
         ? params.node.data.base_os
           ? params.node.data.base_os
           : '-'
         : '';
     this.os_scan_status =
-      params && params.node.data
+      params && params.node?.data
         ? params.node.data.os_scan_status
           ? params.node.data.os_scan_status
           : this.OS_STATUS.UNKNOWN
         : '';
-  }
-
-  refresh(params: ICellRendererParams): boolean {
-    this.params = params;
-    return true;
   }
 }

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
@@ -64,6 +64,10 @@ export class RegistryDetailsTableComponent implements OnInit, OnChanges {
     {
       field: 'base_os',
       cellRenderer: 'osCellRenderer',
+      valueGetter: params =>
+        params.data
+          ? `${params.data.base_os}_${params.data.os_scan_status}`
+          : '',
       headerValueGetter: () => this.translate.instant('scan.gridHeader.OS'),
       minWidth: 200,
     },

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-table.component.ts
@@ -76,6 +76,10 @@ export class RegistryDetailsTableComponent implements OnInit, OnChanges {
     {
       field: 'vulnerabilities',
       cellRenderer: 'vulnerabilitiesCellRenderer',
+      valueGetter: params =>
+        params.data
+          ? `${params.data.critical}_${params.data.high}_${params.data.medium}`
+          : '',
       comparator: (valueA, valueB, nodeA, nodeB) => {
         if (
           nodeA.data.critical + nodeA.data.high + nodeA.data.medium ===

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-vulnerabilities-cell/registry-details-vulnerabilities-cell.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-vulnerabilities-cell/registry-details-vulnerabilities-cell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { ICellRendererAngularComp } from 'ag-grid-angular';
 import { ICellRendererParams } from 'ag-grid-community';
 
@@ -11,18 +11,26 @@ import { ICellRendererParams } from 'ag-grid-community';
 })
 export class RegistryDetailsVulnerabilitiesCellComponent implements ICellRendererAngularComp {
   params!: ICellRendererParams;
-  critical!: string;
-  high!: string;
-  medium!: string;
+  critical!: number | string;
+  high!: number | string;
+  medium!: number | string;
+
+  constructor(private cd: ChangeDetectorRef) {}
 
   agInit(params: ICellRendererParams): void {
-    this.params = params;
-    this.critical = params && params.node.data ? params.node.data.critical : 0;
-    this.high = params && params.node.data ? params.node.data.high : 0;
-    this.medium = params && params.node.data ? params.node.data.medium : 0;
+    this.updateValues(params);
   }
 
   refresh(params: ICellRendererParams): boolean {
-    return false;
+    this.updateValues(params);
+    this.cd.markForCheck();
+    return true;
+  }
+
+  private updateValues(params: ICellRendererParams): void {
+    this.params = params;
+    this.critical = params && params.node?.data ? params.node.data.critical : 0;
+    this.high = params && params.node?.data ? params.node.data.high : 0;
+    this.medium = params && params.node?.data ? params.node.data.medium : 0;
   }
 }

--- a/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-vulnerabilities-cell/registry-details-vulnerabilities-cell.component.ts
+++ b/admin/webapp/websrc/app/routes/registries/registry-details/registry-details-table/registry-details-vulnerabilities-cell/registry-details-vulnerabilities-cell.component.ts
@@ -11,9 +11,9 @@ import { ICellRendererParams } from 'ag-grid-community';
 })
 export class RegistryDetailsVulnerabilitiesCellComponent implements ICellRendererAngularComp {
   params!: ICellRendererParams;
-  critical!: number | string;
-  high!: number | string;
-  medium!: number | string;
+  critical: number = 0;
+  high: number = 0;
+  medium: number = 0;
 
   constructor(private cd: ChangeDetectorRef) {}
 
@@ -29,8 +29,8 @@ export class RegistryDetailsVulnerabilitiesCellComponent implements ICellRendere
 
   private updateValues(params: ICellRendererParams): void {
     this.params = params;
-    this.critical = params && params.node?.data ? params.node.data.critical : 0;
-    this.high = params && params.node?.data ? params.node.data.high : 0;
-    this.medium = params && params.node?.data ? params.node.data.medium : 0;
+    this.critical = params && params.node?.data ? params.node.data.critical ?? 0 : 0;
+    this.high = params && params.node?.data ? params.node.data.high ?? 0 : 0;
+    this.medium = params && params.node?.data ? params.node.data.medium ?? 0 : 0;
   }
 }


### PR DESCRIPTION
## Description

Fix #1272 make sure "Vulnerabilities" column always shows the correct number in "Details" section


## Test
1. In the Registries page, select an unscanned or newly added registry from the top table.
2. Ensure the bottom section displays the registry details and the Details tab is active.
3. Click the Start Scan button.Observe the bottom table while the scan progresses. 
4. Verify: The Vulnerabilities column dynamically updates from 0 0 0 to show the correct non-zero badge counts (Critical, High, Medium).

<!-- Please describe, if any, potential improvement that you are envisioning -->
<img width="1787" height="797" alt="Screenshot 2026-08-23 at 7 45 31 PM" src="https://github.com/user-attachments/assets/a40fe152-37cd-4e5c-a87e-153be8b6db6b" />
