### PR TITLE
Fix typo in cli

### DIFF
--- a/cli/prog/auth.py
+++ b/cli/prog/auth.py
@@ -215,7 +215,7 @@ def set_user_local_config(data, global_role, timeout, email, locale, password):
         user["locale"] = locale
     if password == True:
         if data.username == data.id_or_name:
-            # set currrent login user's password
+            # set current login user's password
             current = click.prompt("Current Password", hide_input=True)
         pass1 = click.prompt("New Password", hide_input=True)
         pass2 = click.prompt("Confirm Password", hide_input=True)
@@ -246,7 +246,7 @@ def set_user_local_config(data, global_role, timeout, email, locale, password):
 @click.option('--domain', '-d', multiple=True, help="Domains of the role.")
 @click.pass_obj
 def set_user_local_role(data, role, domain):
-    """Set user role domain access control. Users with global role fedAdmin cannot be assined domain roles."""
+    """Set user role domain access control. Users with global role fedAdmin cannot be assigned domain roles."""
 
     if len(domain) > 0:
         user = {"fullname": data.id_or_name, "role": role, "domains": domain}

--- a/cli/prog/conversation.py
+++ b/cli/prog/conversation.py
@@ -9,42 +9,42 @@ from prog import output
 from prog import utils
 
 
-def _show_display_format(conver):
+def _show_display_format(conversation):
     f = "bytes"
-    if f in conver:
+    if f in conversation:
         fo = output.key_output(f)
-        conver[fo] = utils.convert_byte(conver[f], 0)
+        conversation[fo] = utils.convert_byte(conversation[f], 0)
 
 
-def _list_display_format(conver, src, dst, id_only):
+def _list_display_format(conversation, src, dst, id_only):
     if src["kind"] == client.EndpointKindContainer:
         if id_only:
-            conver["client"] = "%s" % src["id"][:output.SHORT_ID_LENGTH]
+            conversation["client"] = "%s" % src["id"][:output.SHORT_ID_LENGTH]
         else:
-            conver["client"] = "%s - %s" % (src["id"][:output.SHORT_ID_LENGTH], src["display_name"])
+            conversation["client"] = "%s - %s" % (src["id"][:output.SHORT_ID_LENGTH], src["display_name"])
     else:
-        conver["client"] = src["id"]
+        conversation["client"] = src["id"]
 
     if dst["kind"] == client.EndpointKindContainer:
         if id_only:
-            conver["server"] = "%s" % dst["id"][:output.SHORT_ID_LENGTH]
+            conversation["server"] = "%s" % dst["id"][:output.SHORT_ID_LENGTH]
         else:
-            conver["server"] = "%s - %s" % (dst["id"][:output.SHORT_ID_LENGTH], dst["display_name"])
+            conversation["server"] = "%s - %s" % (dst["id"][:output.SHORT_ID_LENGTH], dst["display_name"])
     else:
-        conver["server"] = dst["id"]
+        conversation["server"] = dst["id"]
 
     f = "applications"
-    if f in conver:
-        conver[output.key_output(f)] = ",".join(conver[f])
+    if f in conversation:
+        conversation[output.key_output(f)] = ",".join(conversation[f])
     else:
-        conver[output.key_output(f)] = ""
+        conversation[output.key_output(f)] = ""
     f = "ports"
-    if f in conver:
-        conver[output.key_output(f)] = ",".join(conver[f])
+    if f in conversation:
+        conversation[output.key_output(f)] = ",".join(conversation[f])
     else:
-        conver[output.key_output(f)] = ""
+        conversation[output.key_output(f)] = ""
 
-    _show_display_format(conver)
+    _show_display_format(conversation)
 
 
 @show.group("conversation", invoke_without_command=True)
@@ -55,7 +55,7 @@ def _list_display_format(conver, src, dst, id_only):
 @click.option("--page", default=40, type=click.IntRange(1), help="list page size, default=40")
 @click.pass_obj
 @click.pass_context
-def show_conver(ctx, data, group, domain, verbose, id_only, page):
+def show_conversation(ctx, data, group, domain, verbose, id_only, page):
     """Show conversations."""
     if ctx.invoked_subcommand is not None:
         return
@@ -75,10 +75,10 @@ def show_conver(ctx, data, group, domain, verbose, id_only, page):
         for ep in data["endpoints"]:
             eps[ep["id"]] = ep
 
-    convers = data["conversations"]
+    conversations = data["conversations"]
     fromid = ""
     toid = ""
-    for c in convers:
+    for c in conversations:
         if verbose:
             fromid = c["from"]["id"]
             toid = c["to"]["id"]
@@ -106,7 +106,7 @@ def show_conver(ctx, data, group, domain, verbose, id_only, page):
             _list_display_format(c, eps[fromid], eps[toid], id_only)
 
     start = 0
-    size = len(convers)
+    size = len(conversations)
     while True:
         if start + page > size:
             end = size
@@ -115,7 +115,7 @@ def show_conver(ctx, data, group, domain, verbose, id_only, page):
 
         columns = (
         "client", "server", "policy_action", "severity", "bytes", "sessions", "applications", "ports", "xff_entry")
-        output.list(columns, convers[start:end])
+        output.list(columns, conversations[start:end])
 
         start = end
         if start >= size:
@@ -127,7 +127,7 @@ def show_conver(ctx, data, group, domain, verbose, id_only, page):
             break
 
 
-@show_conver.command()
+@show_conversation.command()
 @click.argument("client")
 @click.argument("server")
 @click.pass_obj
@@ -139,17 +139,17 @@ def pair(data, client, server):
     s = utils.get_managed_object_id(data.client, "workload", "workload", server)
     if not s:
         s = server
-    conver = data.client.show("conversation/%s" % c, "conversation", s)
+    conversation = data.client.show("conversation/%s" % c, "conversation", s)
 
-    for e in conver["entries"]:
+    for e in conversation["entries"]:
         _show_display_format(e)
 
     columns = ("port", "mapped_port", "application", "policy_action", "policy_id", "severity",
                "bytes", "sessions", "last_seen_at", "client_ip", "server_ip", "fqdn", "xff", "to_sidecar")
-    output.list(columns, conver["entries"])
+    output.list(columns, conversation["entries"])
 
 
-@show_conver.command()
+@show_conversation.command()
 @click.option('-v', '--view', type=click.Choice(['', 'pod']), default='', help="specify view")
 @click.option("-g", "--group", default=None, help="filter endpoints by group")
 @click.option("--page", default=40, type=click.IntRange(1), help="list page size, default=40")
@@ -184,7 +184,7 @@ def endpoint(data, view, group, page):
 @delete.group("conversation", invoke_without_command=True)
 @click.pass_obj
 @click.pass_context
-def delete_conver(ctx, data):
+def delete_conversation(ctx, data):
     """Delete all conversations."""
     if ctx.invoked_subcommand is not None:
         return
@@ -192,7 +192,7 @@ def delete_conver(ctx, data):
     data.client.delete("conversation", None)
 
 
-@delete_conver.command()
+@delete_conversation.command()
 @click.argument("client")
 @click.argument("server")
 @click.pass_obj
@@ -204,10 +204,10 @@ def pair(data, client, server):
     s = utils.get_managed_object_id(data.client, "workload", "workload", server)
     if not s:
         s = server
-    conver = data.client.delete("conversation/%s/%s" % (c, s), None)
+    conversation = data.client.delete("conversation/%s/%s" % (c, s), None)
 
 
-@delete_conver.command()
+@delete_conversation.command()
 @click.argument("endpoint")
 @click.pass_obj
 @click.pass_context
@@ -218,11 +218,11 @@ def endpoint(ctx, data, endpoint):
 
 @cli_set.group("conversation")
 @click.pass_obj
-def set_conver(data):
+def set_conversation(data):
     """Set conversation configuration."""
 
 
-@set_conver.command("endpoint")
+@set_conversation.command("endpoint")
 @click.argument("endpoint")
 @click.option('--alias', help="Set endpoint alias.")
 @click.pass_obj
@@ -237,11 +237,11 @@ def set_endpoint(data, endpoint, alias):
 
 @unset.group("conversation")
 @click.pass_obj
-def unset_conver(data):
+def unset_conversation(data):
     """Unset conversation configuration."""
 
 
-@unset_conver.command("endpoint")
+@unset_conversation.command("endpoint")
 @click.argument("endpoint")
 @click.option('--alias', is_flag=True, help="Unset endpoint alias.")
 @click.pass_obj

--- a/cli/prog/diag.py
+++ b/cli/prog/diag.py
@@ -303,7 +303,7 @@ def pcap(data, filename, limit, id):
 
     click.echo("read end")
     kwargs = {'strict': True}
-    clen = int(headers.get('Content-Length', '-1'))
+    contentLen = int(headers.get('Content-Length', '-1'))
     ctype, options = multipart.parse_options_header(headers.get("Content-Type"))
     boundary = options.get('boundary', '')
     if ctype != 'multipart/form-data' or not boundary:
@@ -311,7 +311,7 @@ def pcap(data, filename, limit, id):
         return
 
     try:
-        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, clen):
+        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, contentLen):
             if part.name == "pcap" and part.content_type == "application/cap":
                 click.echo("write %d" % len(part.raw))
                 _write_part(part, filename)

--- a/cli/prog/group.py
+++ b/cli/prog/group.py
@@ -390,10 +390,10 @@ def custom_check(data, id_or_name):
     if not group:
         return
 
-    enabledDsiplay = "enabled"
+    enabledDisplay = "enabled"
     if not group["enabled"]:
-        enabledDsiplay = "disabled"
-    click.echo("custom check is {}".format(enabledDsiplay))
+        enabledDisplay = "disabled"
+    click.echo("custom check is {}".format(enabledDisplay))
     click.echo("")
     
     if not group["writable"]:
@@ -554,7 +554,7 @@ def set_group_setting(data, image, node, domain, container, service, label, addr
     """Set group configuration.
 
     For partial match, add @ in front of the value streig, for example --image @nginx.
-    if the option value starts with ^, the criterion matches strign with prefix 'value'.
+    if the option value starts with ^, the criterion matches string with prefix 'value'.
     For --label, use: key=value, key^value or key@value.
     For --address, use: --address=1.2.3.4, --address=1.2.3.0/24, --address 1.2.3.1-1.2.3.31
     To input an empty string, use: --service =

--- a/cli/prog/host.py
+++ b/cli/prog/host.py
@@ -60,7 +60,7 @@ def detail(data, id_or_name):
 @click.argument("id_or_name")
 @click.pass_obj
 def ip_2_container(data, id_or_name):
-    """Show node ip-continer map."""
+    """Show node ip-container map."""
     host = utils.get_managed_object(data.client, "host", "host", id_or_name)
     if not host:
         return

--- a/cli/prog/main.py
+++ b/cli/prog/main.py
@@ -15,7 +15,7 @@ from prog import client
 from prog import cluster
 from prog import compliance
 from prog import controller
-from prog import convers
+from prog import conversation
 from prog import diag
 from prog import dlp
 from prog import waf

--- a/cli/prog/multipart.py
+++ b/cli/prog/multipart.py
@@ -292,7 +292,7 @@ class MultipartParser(object):
 
         # For each part in stream...
         mem_used, disk_used = 0, 0  # Track used resources to prevent DoS
-        is_tail = False  # True if the last line was incomplete (cutted)
+        is_tail = False  # True if the last line was incomplete (cut)
 
         opts = {
             "buffer_size": self.buffer_size,

--- a/cli/prog/policy.py
+++ b/cli/prog/policy.py
@@ -471,7 +471,7 @@ def create_response_rule(data, scope, group, event, condition, action, webhook, 
 @set.group("response")
 @click.pass_obj
 def set_response(data):
-    """Set reponse rule configuration."""
+    """Set response rule configuration."""
 
 
 @set_response.command("rule")
@@ -543,13 +543,13 @@ def set_response_rule(data, id, scope, group, event, condition, action, webhook,
 @unset.group("response")
 @click.pass_obj
 def unset_response(data):
-    """Unset reponse rule configuration."""
+    """Unset response rule configuration."""
 
 
 @unset_response.group("rule")
 @click.pass_obj
 def unset_response_rule(data):
-    """Unset reponse rule configuration."""
+    """Unset response rule configuration."""
 
 
 @unset_response_rule.command("group")

--- a/cli/prog/pwd_profile.py
+++ b/cli/prog/pwd_profile.py
@@ -53,7 +53,7 @@ def detail(data, name):
 
     if profile["enable_block_after_failed_login"] is True and profile["block_after_failed_login_count"] > 0 and profile[
         "block_minutes"] > 0:
-        profile[header1] = "block {} minutes after {} consecutive login faulures".format(profile["block_minutes"],
+        profile[header1] = "block {} minutes after {} consecutive login failures".format(profile["block_minutes"],
                                                                                          profile[
                                                                                              "block_after_failed_login_count"])
     else:

--- a/cli/prog/system.py
+++ b/cli/prog/system.py
@@ -444,7 +444,7 @@ def internal_subnets(data):
 @click.option("--page", default=20, type=click.IntRange(1), help="list page size, default=20")
 @click.pass_obj
 def ip_2_container(data, page):
-    """Show ip-continer map."""
+    """Show ip-container map."""
     filter = {"start": 0, "limit": page}
     while True:
         wls = data.client.list("debug/ip2workload", "ip_2_workload", **filter)
@@ -656,7 +656,7 @@ def set_system(data):
 @set_system.group('new_service')
 @click.pass_obj
 def set_system_new_service(data):
-    """Set system new service configruation"""
+    """Set system new service configuration"""
 
 
 @set_system_new_service.command("policy_mode")
@@ -686,7 +686,7 @@ def set_system_new_service_profile_baseline(data, baseline):
 @set_system.group('unused_group')
 @click.pass_obj
 def set_system_unused_group(data):
-    """Set system unused group configruation"""
+    """Set system unused group configuration"""
 
 
 @set_system_unused_group.command("aging")
@@ -868,7 +868,7 @@ def set_system_controller_debug(data, category):
 @click.argument('order')
 @click.pass_obj
 def set_system_auth_order(data, order):
-    """Set authentication order in comma-seperated server names"""
+    """Set authentication order in comma-separated server names"""
     servers = order.split(",")
     data.client.config_system(auth_order=servers)
 
@@ -1384,7 +1384,7 @@ def export_config(data, section, raw, filename):
         return
 
     kwargs = {'strict': True}
-    clen = int(headers.get('Content-Length', '-1'))
+    contentLen = int(headers.get('Content-Length', '-1'))
     ctype, options = multipart.parse_options_header(headers.get("Content-Type"))
     boundary = options.get('boundary', '')
     if ctype != 'multipart/form-data' or not boundary:
@@ -1392,7 +1392,7 @@ def export_config(data, section, raw, filename):
         return
 
     try:
-        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, clen):
+        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, contentLen):
             if part.name == "configuration" and part.content_type == "application/x-gzip":
                 _write_part(part, filename)
                 return
@@ -1833,7 +1833,7 @@ def import_compliance_profile(data, filename):
 @click.option("-t", "--tail", default=0, help="number of lines to show from the end of debug logs ")
 @click.option("-f", "--filename", default="/var/neuvector/nv_debug",
               type=click.Path(dir_okay=False, writable=True, resolve_path=True), \
-              help="location to store the ouput")
+              help="location to store the output")
 @click.pass_obj
 def debug(data, enforcer, tail, filename):
     """Request export debug """
@@ -1854,7 +1854,7 @@ def debug(data, enforcer, tail, filename):
         url += "?" + filter
 
     headers, body = data.client.download(url, None)
-    clen = int(headers.get('Content-Length', '-1'))
+    contentLen = int(headers.get('Content-Length', '-1'))
     ctype, options = multipart.parse_options_header(headers.get("Content-Type"))
     boundary = options.get('boundary', '')
     if ctype != 'multipart/form-data' or not boundary:
@@ -1864,7 +1864,7 @@ def debug(data, enforcer, tail, filename):
     if filename.endswith(".tar.gz") == False:
         filename += ".tar.gz"
     try:
-        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, clen):
+        for part in multipart.MultipartParser(io.BytesIO(body.content), boundary, contentLen):
             if part.name == "debug" and part.content_type == "application/x-gzip":
                 _write_part(part, filename)
                 return
@@ -1933,7 +1933,7 @@ def delete(data):
 @set_system.group('auto_mode')
 @click.pass_obj
 def set_system_config_atmo(data):
-    """Set system auto mode upgrader configruation"""
+    """Set system auto mode upgrader configuration"""
 
 @set_system_config_atmo.command("config")
 @click.option("-p","--path", default="d2m", type=click.Choice(["d2m", "m2p"]), help="d2m: Discover to Monitor, m2p: Monitor to Protect")


### PR DESCRIPTION
## Description

Fix typos in cli
Do not fix ``assemblys` should be `assemblies`` in `cli/prog/enforcer.py` yet because they are related to REST API spec.
```
("total_assemblys", "TCP ASM"),
("freed_assemblys", "TCP ASM freed"),
```

## Additional Information

### Tradeoff

### Potential improvement

